### PR TITLE
Fix chunkify ordering bug for 2 layers

### DIFF
--- a/lib/annex/layer/dropout.ex
+++ b/lib/annex/layer/dropout.ex
@@ -4,8 +4,11 @@ defmodule Annex.Layer.Dropout do
     Layer.Backprop,
     Layer.Dropout,
     Layer.ListLayer,
+    Type,
     Utils
   }
+
+  require Type
 
   @behaviour Layer
 
@@ -34,16 +37,14 @@ defmodule Annex.Layer.Dropout do
   end
 
   @spec feedforward(t(), ListLayer.t()) :: {t(), ListLayer.t()}
-  def feedforward(%Dropout{frequency: frequency} = layer, inputs) do
+  def feedforward(%Dropout{frequency: frequency} = layer, inputs)
+      when Type.is_list_of_floats(inputs) do
     {layer, drop(inputs, frequency)}
   end
 
   @spec drop(ListLayer.t(), float()) :: ListLayer.t()
-  def drop(inputs, frequency) do
-    inputs
-    |> Enum.map(fn row ->
-      Enum.map(row, fn value -> zeroize_by_frequency(frequency, value) end)
-    end)
+  def drop(inputs, frequency) when Type.is_list_of_floats(inputs) do
+    Enum.map(inputs, fn value -> zeroize_by_frequency(frequency, value) end)
   end
 
   defp zeroize_by_frequency(frequency, value) do

--- a/lib/annex/layer/sequence.ex
+++ b/lib/annex/layer/sequence.ex
@@ -68,6 +68,7 @@ defmodule Annex.Layer.Sequence do
   def init_layer(%Sequence{initialized?: false} = seq1, _opts) do
     seq1
     |> get_layers()
+    |> prepare_for_chunkify()
     |> chunkify()
     |> Enum.map(fn {previous_layer, layer, next_layer} ->
       layer_opts = [
@@ -189,32 +190,19 @@ defmodule Annex.Layer.Sequence do
     end)
   end
 
-  defp chunkify([]) do
-    []
+  defp prepare_for_chunkify(layers) do
+    [nil] ++ layers ++ [nil]
   end
 
-  defp chunkify([one]) do
-    [{nil, one, nil}]
+  defp chunkify(prepared_layers) do
+    chunkify(prepared_layers, [])
   end
 
-  defp chunkify([one, two]) do
-    [{one, two, nil}, {nil, one, two}]
-  end
-
-  defp chunkify([prev, current, next | rest]) do
-    acc = [
-      {prev, current, next},
-      {nil, prev, current}
-    ]
-
-    chunkify([current, next | rest], acc)
+  defp chunkify([prev, current, next], acc) do
+    Enum.reverse([{prev, current, next} | acc])
   end
 
   defp chunkify([prev, current, next | rest], acc) do
     chunkify([current, next | rest], [{prev, current, next} | acc])
-  end
-
-  defp chunkify([prev, current], acc) do
-    Enum.reverse([{prev, current, nil} | acc])
   end
 end

--- a/lib/annex/type.ex
+++ b/lib/annex/type.ex
@@ -1,0 +1,3 @@
+defmodule Annex.Type do
+  defguard is_list_of_floats(floats) when is_float(hd(floats))
+end

--- a/test/annex/layer/dropout_test.exs
+++ b/test/annex/layer/dropout_test.exs
@@ -1,6 +1,10 @@
 defmodule Annex.Layer.DropoutTest do
   use ExUnit.Case
-  alias Annex.Layer.Dropout
+
+  alias Annex.{
+    Layer.Dropout,
+    Layer
+  }
 
   describe "build/1" do
     test "works for frequency above 0.0 and less than or equal to 1.0" do
@@ -14,6 +18,26 @@ defmodule Annex.Layer.DropoutTest do
       assert_raise(FunctionClauseError, fn -> Dropout.build(1) end)
       assert_raise(FunctionClauseError, fn -> Dropout.build(:one) end)
       assert_raise(FunctionClauseError, fn -> Dropout.build(-1.0) end)
+    end
+
+    test "dropout can handle a list of floats" do
+      layer1 = Dropout.build(0.5)
+      original = 0.666
+      {_layer2, pred} = Layer.feedforward(layer1, [original])
+      assert [zeroed_or_original] = pred
+      assert zeroed_or_original in [1.0, 0.0]
+    end
+
+    test "dropout does not change on feedforward" do
+      layer1 = Dropout.build(0.5)
+      {layer2, _pred} = Layer.feedforward(layer1, [1.0])
+      assert layer1 == layer2
+    end
+
+    test "dropout does not change on init_layer" do
+      layer1 = Dropout.build(0.5)
+      {:ok, layer2} = Layer.init(layer1)
+      assert layer1 == layer2
     end
   end
 end

--- a/test/annex/layer/dropout_test.exs
+++ b/test/annex/layer/dropout_test.exs
@@ -25,7 +25,7 @@ defmodule Annex.Layer.DropoutTest do
       original = 0.666
       {_layer2, pred} = Layer.feedforward(layer1, [original])
       assert [zeroed_or_original] = pred
-      assert zeroed_or_original in [1.0, 0.0]
+      assert zeroed_or_original in [original, 0.0]
     end
 
     test "dropout does not change on feedforward" do

--- a/test/annex/layer/sequence_test.exs
+++ b/test/annex/layer/sequence_test.exs
@@ -1,0 +1,109 @@
+defmodule Annex.Layer.SequenceTest do
+  use ExUnit.Case
+
+  alias Annex.Layer.{Sequence, Dense, Activation, Dropout, Backprop}
+
+  def generate_n_layers(n) do
+    [
+      Annex.dense(1, input_dims: 1),
+      Annex.activation(:sigmoid),
+      Annex.dropout(0.5)
+    ]
+    |> Stream.cycle()
+    |> Enum.take(n)
+  end
+
+  def in_order?([%Dense{}, %Activation{} | _rest]), do: true
+  def in_order?([%Activation{}, %Dropout{} | _rest]), do: true
+  def in_order?([%Dropout{}, %Dense{} | _rest]), do: true
+  def in_order?(_), do: false
+
+  def all_in_order?([_]), do: true
+
+  def all_in_order?(layers) do
+    if in_order?(layers) do
+      layers
+      |> tl()
+      |> all_in_order?()
+    else
+      false
+    end
+  end
+
+  def assert_in_order(%Sequence{layers: layers}) do
+    assert_in_order(layers)
+  end
+
+  def assert_in_order(layers) when is_list(layers) do
+    assert all_in_order?(layers), "Layers were not in order: #{inspect(layers)}"
+  end
+
+  def run_order_assertions(n, seq_transform) do
+    layers = generate_n_layers(n)
+    assert length(layers) == n
+    assert_in_order(layers)
+    seq = seq_transform.(layers)
+    seq_layers = Sequence.get_layers(seq)
+    assert length(seq_layers) == n
+    assert_in_order(seq_layers)
+  end
+
+  setup do
+    seq = Annex.sequence(generate_n_layers(10))
+    {:ok, %{seq: seq}}
+  end
+
+  describe "layer ordering:" do
+    test "order helpers work" do
+      layers = generate_n_layers(10)
+      assert all_in_order?(layers)
+      refute layers |> Enum.reverse() |> all_in_order?
+    end
+
+    test "Annex.sequence/2 preserves ordering of 2 layers" do
+      run_order_assertions(2, fn layers ->
+        Annex.sequence(layers)
+      end)
+    end
+
+    test "Annex.sequence/2 preserves ordering of 3 layers" do
+      run_order_assertions(3, fn layers ->
+        Annex.sequence(layers)
+      end)
+    end
+
+    test "Annex.sequence/2 preserves ordering of 10 layers" do
+      run_order_assertions(10, fn layers ->
+        Annex.sequence(layers)
+      end)
+    end
+
+    test "Sequence.init_layer/1 preserves ordering of layers", %{seq: seq} do
+      assert_in_order(seq)
+      assert seq.initialized? == false
+      assert {:ok, seq2} = Sequence.init_layer(seq)
+      assert_in_order(seq)
+    end
+
+    test "Sequence.feedforward/2 preserves ordering of layers", %{seq: seq} do
+      assert_in_order(seq)
+      assert seq.initialized? == false
+      assert {:ok, seq2} = Sequence.init_layer(seq)
+      assert_in_order(seq2)
+      assert {%Sequence{} = seq3, _} = Sequence.feedforward(seq2, [1.0])
+      assert_in_order(seq3)
+    end
+
+    test "Sequence.backprop/2 preserves ordering of layers", %{seq: seq} do
+      assert_in_order(seq)
+      assert seq.initialized? == false
+      assert {:ok, seq2} = Sequence.init_layer(seq)
+      assert_in_order(seq2)
+      assert {%Sequence{} = seq3, _} = Sequence.feedforward(seq2, [1.0])
+      assert_in_order(seq3)
+      props = Backprop.new(cost_gradient: 0.03, net_loss: 0.1, loss_pds: [0.4])
+      assert {%Sequence{} = seq4, _, _} = Sequence.backprop(seq3, [1.0], props)
+      assert_in_order(seq4)
+    end
+  end
+end


### PR DESCRIPTION
There was a bug that occurred when a Sequence had 2 layer that the `chunkify/1` function called during `Sequence.init_layer` would flip the order of the layers.

- [x] Fixed chunkify functionality
- [x] Added Sequence ordering tests
- [x] Fixed dropout to handle list of floats