### PR TITLE
defer casting when shape is :defer

### DIFF
--- a/lib/annex/data.ex
+++ b/lib/annex/data.ex
@@ -42,6 +42,12 @@ defmodule Annex.Data do
   """
 
   def cast(:defer, data, _) do
+    # defer if type is :defer
+    data
+  end
+
+  def cast(_type, data, :defer) do
+    # defer if shape is :defer
     data
   end
 
@@ -57,16 +63,8 @@ defmodule Annex.Data do
       """
   end
 
-  def cast(:defer, data, _) do
-    data
-  end
-
   def cast(type, data, shape) when is_tuple(shape) and is_atom(type) do
     type.cast(data, shape)
-  end
-
-  def cast(type, data, :defer) when is_atom(type) do
-    type.cast(data, :defer)
   end
 
   @doc """


### PR DESCRIPTION
In this PR we defer `Annex.Data` casting when the shape is `:defer` instead of passing deferment to the given type.