### PR TITLE
Jg/generalize dense data

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,4 +6,6 @@ config :annex,
     cost: Annex.Cost.MeanSquaredError
   ]
 
+config :annex, Annex.Layer.Dense, data_type: Annex.Data.DMatrix
+
 import_config("#{Mix.env()}.exs")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,5 @@
 use Mix.Config
 
 config :annex, Annex.Data.DTensor, debug: true
+
+config :annex, Annex.Layer.Dense, data_type: Annex.Data.DMatrix

--- a/lib/annex/data.ex
+++ b/lib/annex/data.ex
@@ -20,7 +20,6 @@ defmodule Annex.Data do
   A module that implements the Annex.Data Behaviour.
   """
   @type type :: module()
-
   @type flat_data :: [float(), ...]
   @type data :: struct() | flat_data() | [flat_data()]
   @type op :: any()
@@ -71,6 +70,26 @@ defmodule Annex.Data do
     data
     |> infer_type()
     |> cast(data, shape)
+  end
+
+  @spec cast!(type(), data(), Shape.t()) :: Data.data()
+  def cast!(type, data, shape) do
+    type
+    |> cast(data, shape)
+    |> case do
+      {:ok, casted} ->
+        casted
+
+      {:error, %AnnexError{} = error} ->
+        raise error
+    end
+  end
+
+  @spec cast!(data(), Shape.t()) :: Data.data()
+  def cast!(data, shape) do
+    data
+    |> infer_type()
+    |> cast!(data, shape)
   end
 
   @doc """

--- a/lib/annex/layer/dense.ex
+++ b/lib/annex/layer/dense.ex
@@ -11,7 +11,8 @@ defmodule Annex.Layer.Dense do
     Data.Shape,
     Layer,
     Layer.Backprop,
-    Layer.Dense
+    Layer.Dense,
+    Utils
   }
 
   require Data
@@ -46,6 +47,7 @@ defmodule Annex.Layer.Dense do
             initialized?: false,
             data_type: @default_data_type
 
+  @spec build(pos_integer, pos_integer) :: t()
   def build(rows, columns) when is_pos_integer(rows) and is_pos_integer(columns) do
     %Dense{
       rows: rows,
@@ -53,40 +55,54 @@ defmodule Annex.Layer.Dense do
     }
   end
 
+  @spec build(pos_integer()) :: t()
   def build(rows) when is_pos_integer(rows) do
     %Dense{rows: rows}
   end
 
-  def build(rows, columns, weights, biases) do
-    debug_assert "Dense rows must be a positive integer", do: is_integer(rows)
-    debug_assert "Dense rows must be a positive integer", do: rows > 0
-    debug_assert "Dense columns must be a positive integer", do: is_integer(columns)
-    debug_assert "Dense columns must be a positive integer", do: columns > 0
-
-    debug_assert "Dense weights must be a list of floats" do
-      is_list(weights) || DMatrix.is_type?(weights)
+  @spec build(pos_integer, pos_integer, [float, ...], [float, ...]) :: t()
+  def build(rows, columns, weights, biases, opts \\ []) do
+    debug_assert "Dense rows must be a positive integer" do
+      is_int? = is_integer(rows)
+      is_positive? = rows > 0
+      is_int? && is_positive?
     end
 
-    debug_assert "Dense weights must be a list of floats" do
-      Enum.all?(weights, &is_float/1)
+    debug_assert "Dense columns must be a positive integer" do
+      is_int? = is_integer(columns)
+      is_positive? = columns > 0
+      is_int? && is_positive?
+    end
+
+    debug_assert "Dense weights must be an Annex.Data" do
+      type = Data.infer_type(weights)
+      Data.is_type?(type, weights)
     end
 
     debug_assert "Dense biases must be a list of floats" do
-      is_list(biases) || DMatrix.is_type?(biases)
+      type = Data.infer_type(biases)
+      Data.is_type?(type, biases)
     end
 
-    debug_assert "Dense biases must be a list of floats", do: Enum.all?(biases, &is_float/1)
+    debug_assert "Dense biases shape must be compatible with Dense shape" do
+      {biases_rows, biases_columns} =
+        case Data.shape(biases) do
+          {rows} -> {rows, 1}
+          {rows, cols} -> {rows, cols}
+        end
 
-    debug_assert "Dense biases must be the same length as the count of rows" do
-      is_list(biases) && length(biases) == rows
+      biases_rows == rows && biases_columns == 1
     end
+
+    data_type = Keyword.get(opts, :data_type, @default_data_type)
 
     %Dense{
-      biases: DMatrix.build(biases, rows, 1),
-      weights: DMatrix.build(weights, rows, columns),
+      biases: Data.cast!(data_type, biases, {rows, 1}),
+      weights: Data.cast!(data_type, weights, {rows, columns}),
       rows: rows,
       columns: columns,
-      initialized?: true
+      initialized?: true,
+      data_type: data_type
     }
   end
 
@@ -113,8 +129,6 @@ defmodule Annex.Layer.Dense do
   end
 
   def init_layer(%Dense{initialized?: false} = dense, opts) do
-    previous_layer = Keyword.get(opts, :previous_layer)
-    next_layer = Keyword.get(opts, :next_layer)
     rows = resolve_init_rows(dense, opts)
     columns = columns(dense)
 
@@ -138,43 +152,32 @@ defmodule Annex.Layer.Dense do
 
   defp resolve_init_weights(%Dense{} = dense, rows, columns) do
     dense
-    |> get_weights()
-    |> build_dmatrix(rows, columns, fn ->
-      DMatrix.new_random(rows, columns)
+    |> data_type()
+    |> build_data(get_weights(dense), rows, columns, fn ->
+      Utils.random_weights(rows * columns)
     end)
   end
 
   defp resolve_init_biases(%Dense{} = dense, rows) do
     dense
-    |> get_biases()
-    |> build_dmatrix(rows, 1, fn ->
-      DMatrix.ones(rows, 1)
+    |> data_type()
+    |> build_data(get_biases(dense), rows, 1, fn ->
+      fn -> 1.0 end
+      |> Stream.repeatedly()
+      |> Enum.take(rows)
     end)
   end
 
-  defp build_dmatrix(item, rows, columns, builder) do
-    case item do
-      nil ->
-        builder.()
-
-      %DMatrix{} = matrix ->
-        debug_assert "matrix shape matches rows and columns" do
-          shape = DMatrix.shape(matrix)
-          shape == {rows, columns}
-        end
-
-        matrix
-
-      data when Data.is_flat_data(data) ->
-        DMatrix.build(data, rows, columns)
-    end
+  defp build_data(type, data, rows, columns, builder) when is_atom(type) do
+    data = data || builder.()
+    Data.cast!(type, data, {rows, columns})
   end
 
-  def resolve_init_rows(%Dense{rows: rows}, _opts) when is_pos_integer(rows) do
+  defp resolve_init_rows(%Dense{rows: rows}, _opts) when is_pos_integer(rows) do
     rows
   end
 
-  def resolve_init_rows(%Dense{rows: nil}, opts) do
+  defp resolve_init_rows(%Dense{rows: nil}, opts) do
     prev_layer = Keyword.get(opts, :prev_layer)
 
     debug_assert "rows must be specified if there is no previous layer" do
@@ -194,20 +197,22 @@ defmodule Annex.Layer.Dense do
   end
 
   @impl Layer
-  @spec feedforward(t(), DMatrix.t()) :: {t(), DMatrix.t()}
+  @spec feedforward(t(), Data.data()) :: {t(), Data.data()}
   def feedforward(%Dense{} = dense, inputs) do
     debug_assert "Dense.feedforward/2 input must be dottable with the weights" do
       weights = get_weights(dense)
-      {_, dense_columns} = Data.shape(DMatrix, weights)
-      {inputs_rows, _} = Data.shape(DMatrix, inputs)
+      {_, dense_columns} = Data.shape(weights)
+      {inputs_rows, _} = Data.shape(inputs)
       dense_columns == inputs_rows
     end
+
+    biases = get_biases(dense)
 
     output =
       dense
       |> get_weights()
-      |> DMatrix.dot(inputs)
-      |> DMatrix.add(get_biases(dense))
+      |> Data.apply_op(:dot, [inputs])
+      |> Data.apply_op(:add, [biases])
 
     updated_dense = %Dense{
       dense
@@ -220,14 +225,14 @@ defmodule Annex.Layer.Dense do
 
   @impl Layer
   @spec backprop(t(), Data.data(), Backprop.t()) :: {t(), Data.data(), Backprop.t()}
-  def backprop(%Dense{} = dense, %DMatrix{} = error, props) do
+  def backprop(%Dense{} = dense, error, props) do
     learning_rate = Backprop.get_learning_rate(props)
     derivative = Backprop.get_derivative(props)
     output = get_output(dense)
 
     debug_assert "backprop error must have the same shape as output" do
-      output_shape = Data.shape(DMatrix, output)
-      error_shape = Data.shape(DMatrix, error)
+      output_shape = Data.shape(output)
+      error_shape = Data.shape(error)
       output_shape == error_shape
     end
 
@@ -238,29 +243,29 @@ defmodule Annex.Layer.Dense do
 
     gradients =
       output
-      |> DMatrix.map(derivative)
-      |> DMatrix.multiply(error)
-      |> DMatrix.multiply(learning_rate)
+      |> Data.apply_op(:map, [derivative])
+      |> Data.apply_op(:multiply, [error])
+      |> Data.apply_op(:multiply, [learning_rate])
 
-    input_t = DMatrix.transpose(input)
+    input_t = Data.apply_op(input, :transpose, [])
 
     debug_assert "gradients must be dottable with input_T" do
-      {_, gradients_cols} = Data.shape(DMatrix, gradients)
-      {input_rows, _} = Data.shape(DMatrix, input_t)
+      {_, gradients_cols} = Data.shape(gradients)
+      {input_rows, _} = Data.shape(input_t)
 
       gradients_cols == input_rows
     end
 
-    weight_deltas = DMatrix.dot(gradients, input_t)
+    weight_deltas = Data.apply_op(gradients, :dot, [input_t])
 
-    updated_weights = DMatrix.subtract(weights, weight_deltas)
+    updated_weights = Data.apply_op(weights, :subtract, [weight_deltas])
 
-    updated_biases = DMatrix.subtract(biases, gradients)
+    updated_biases = Data.apply_op(biases, :subtract, [gradients])
 
     next_error =
       weights
-      |> DMatrix.transpose()
-      |> DMatrix.dot(error)
+      |> Data.apply_op(:transpose, [])
+      |> Data.apply_op(:dot, [error])
 
     updated_dense = %Dense{
       dense

--- a/lib/annex/layer/dense.ex
+++ b/lib/annex/layer/dense.ex
@@ -20,17 +20,22 @@ defmodule Annex.Layer.Dense do
 
   @behaviour Layer
 
-  @type data_type :: DMatrix.t()
+  @type data :: Data.data()
 
   @type t :: %__MODULE__{
-          weights: data_type() | nil,
-          biases: data_type() | nil,
+          data_type: Data.type(),
+          weights: data() | nil,
+          biases: data() | nil,
           rows: pos_integer() | nil,
           columns: pos_integer() | nil,
-          input: data_type() | nil,
-          output: data_type() | nil,
+          input: data() | nil,
+          output: data() | nil,
           initialized?: boolean()
         }
+
+  @default_data_type :annex
+                     |> Application.get_env(__MODULE__, [])
+                     |> Keyword.get(:data_type, DMatrix)
 
   defstruct weights: nil,
             biases: nil,
@@ -38,7 +43,8 @@ defmodule Annex.Layer.Dense do
             columns: nil,
             input: nil,
             output: nil,
-            initialized?: false
+            initialized?: false,
+            data_type: @default_data_type
 
   def build(rows, columns) when is_pos_integer(rows) and is_pos_integer(columns) do
     %Dense{
@@ -213,7 +219,7 @@ defmodule Annex.Layer.Dense do
   end
 
   @impl Layer
-  @spec backprop(t(), data_type(), Backprop.t()) :: {t(), data_type(), Backprop.t()}
+  @spec backprop(t(), Data.data(), Backprop.t()) :: {t(), Data.data(), Backprop.t()}
   def backprop(%Dense{} = dense, %DMatrix{} = error, props) do
     learning_rate = Backprop.get_learning_rate(props)
     derivative = Backprop.get_derivative(props)
@@ -268,8 +274,8 @@ defmodule Annex.Layer.Dense do
   end
 
   @impl Layer
-  @spec data_type(t()) :: DMatrix
-  def data_type(_), do: DMatrix
+  @spec data_type(t()) :: Data.type()
+  def data_type(%Dense{data_type: data_type}), do: data_type
 
   @impl Layer
   @spec shape(t()) :: Shape.t()

--- a/test/annex/data_test.exs
+++ b/test/annex/data_test.exs
@@ -3,6 +3,8 @@ defmodule Annex.DataTest do
     AnnexError,
     Data,
     Data.DMatrix,
+    Data.List1D,
+    Data.List2D,
     Layer.Dense
   }
 
@@ -117,12 +119,12 @@ defmodule Annex.DataTest do
   describe "infer_type/1" do
     test "List1D for flat list of floats" do
       data = [1.0, 2.0]
-      assert Data.infer_type(data) == Annex.Data.List1D
+      assert Data.infer_type(data) == List1D
     end
 
     test "List2D for flat list of floats" do
       data = [[1.0, 2.0]]
-      assert Data.infer_type(data) == Annex.Data.List2D
+      assert Data.infer_type(data) == List2D
     end
 
     test "works for SimpleData data" do
@@ -131,12 +133,19 @@ defmodule Annex.DataTest do
 
     test "works for DMatrix data" do
       data = DMatrix.build([1.0, 2.0, 3.0])
-      assert Data.infer_type(data) == Annex.Data.DMatrix
+      assert Data.infer_type(data) == DMatrix
     end
 
     test "works for Layer" do
       dense = Dense.build(2, 3)
-      assert Data.infer_type(dense) == Annex.Data.DMatrix
+      assert Data.infer_type(dense) == DMatrix
+    end
+  end
+
+  describe "data_type/1" do
+    test "a Dense layer struct has a default data_type" do
+      dense = %Dense{}
+      assert %Dense{data_type: DMatrix} = dense
     end
   end
 end

--- a/test/annex/layer/dense_test.exs
+++ b/test/annex/layer/dense_test.exs
@@ -133,7 +133,7 @@ defmodule Annex.Layer.DenseTest do
       dense = @dense_2_by_3
       inputs = DMatrix.build([[0.0], [1.0], [0.0]])
       labels = DMatrix.build([[2.0], [0.0]])
-      backprops = [learning_rate: 0.01, derivative: fn x -> 1.0 end]
+      backprops = [learning_rate: 0.01, derivative: fn _ -> 1.0 end]
       # iter 1
       {dense1, output1} = Dense.feedforward(dense, inputs)
       assert output1 == DMatrix.build([[2.0], [1.5]])


### PR DESCRIPTION
In this PR, Annex.Layer.Dense was generalized to handle any Annex.Data type.

Additionally, Annex.Dense is now has a configurable default `:data_type` field on it's struct.