### PR TITLE
Add LayerConfig

### DIFF
--- a/lib/annex.ex
+++ b/lib/annex.ex
@@ -17,7 +17,7 @@ defmodule Annex do
   Given a list of `layers` and `opts` returns a built, but not initialized
   `Sequence`.
   """
-  @spec sequence(list(LayerConfig.t(Sequence))) :: LayerConfig.t(Sequence)
+  @spec sequence(list(LayerConfig.t(module()))) :: LayerConfig.t(Sequence)
   def sequence(layers) when is_list(layers) do
     LayerConfig.build(Sequence, layers: layers)
   end

--- a/lib/annex.ex
+++ b/lib/annex.ex
@@ -5,11 +5,11 @@ defmodule Annex do
 
   alias Annex.{
     Data,
-    LayerConfig,
     Layer.Activation,
     Layer.Dense,
     Layer.Dropout,
     Layer.Sequence,
+    LayerConfig,
     Learner
   }
 

--- a/lib/annex.ex
+++ b/lib/annex.ex
@@ -5,8 +5,7 @@ defmodule Annex do
 
   alias Annex.{
     Data,
-    Data.List1D,
-    Layer,
+    LayerConfig,
     Layer.Activation,
     Layer.Dense,
     Layer.Dropout,
@@ -18,9 +17,9 @@ defmodule Annex do
   Given a list of `layers` and `opts` returns a built, but not initialized
   `Sequence`.
   """
-  @spec sequence(list(struct()), keyword()) :: Sequence.t()
-  def sequence(layers, opts \\ []) when is_list(layers) do
-    Sequence.build(layers, opts)
+  @spec sequence(list(LayerConfig.t(Sequence))) :: LayerConfig.t(Sequence)
+  def sequence(layers) when is_list(layers) do
+    LayerConfig.build(Sequence, layers: layers)
   end
 
   @doc """
@@ -28,9 +27,9 @@ defmodule Annex do
   randomly, at the given frequency, returns `0.0` for an input regardless of
   that input's value.
   """
-  @spec dropout(float()) :: Dropout.t()
+  @spec dropout(float()) :: LayerConfig.t(Dropout)
   def dropout(frequency) do
-    Dropout.build(frequency)
+    LayerConfig.build(Dropout, frequency: frequency)
   end
 
   @doc """
@@ -47,7 +46,8 @@ defmodule Annex do
   def initialize(model, opts \\ []) do
     [
       {is_learner?(model), &Learner.init_learner/2},
-      {is_layer?(model), &Layer.init_layer/2}
+      {is_layer_config?(model), fn cfg, _ -> LayerConfig.init_layer(cfg) end},
+      {is_layer?(model), fn layer, _ -> layer end}
     ]
     |> Enum.group_by(fn {k, _} -> k end, fn {_, v} -> v end)
     |> Map.get(true, [])
@@ -69,19 +69,29 @@ defmodule Annex do
     end)
   end
 
-  defp is_layer?(%module{}), do: function_exported?(module, :init_layer, 2)
-  defp is_layer?(_), do: false
+  defp is_layer_config?(cfg), do: match?(%LayerConfig{}, cfg)
+  defp is_layer?(layer), do: do_module_exports?(layer, {:init_layer, 2})
+  defp is_learner?(learner), do: do_module_exports?(learner, {:init_learner, 2})
 
-  defp is_learner?(%module{}), do: function_exported?(module, :init_learner, 2)
-  defp is_learner?(_), do: false
+  defp do_module_exports?(%module{}, func) do
+    do_module_exports?(module, func)
+  end
+
+  defp do_module_exports?(module, {func, arity}) when is_atom(module) do
+    function_exported?(module, func, arity)
+  end
+
+  defp do_module_exports?(_, _) do
+    false
+  end
 
   @doc """
   Given a number of `rows`, `columns`, some `weights`,
   and some `biases` returns a built `Dense` layer.
   """
-  @spec dense(pos_integer(), pos_integer(), List1D.t(), List1D.t()) :: Dense.t()
+  @spec dense(pos_integer(), pos_integer(), Data.data(), Data.data()) :: LayerConfig.t(Dense)
   def dense(rows, columns, weights, biases) do
-    Dense.build(rows, columns, weights, biases)
+    LayerConfig.build(Dense, rows: rows, columns: columns, weights: weights, biases: biases)
   end
 
   @doc """
@@ -91,9 +101,9 @@ defmodule Annex do
   have no neurons. Upon `Layer.init_layer/2` the Dense layer will be
   initialized with random neurons; Neurons with random weights and biases.
   """
-  @spec dense(pos_integer(), pos_integer()) :: Dense.t()
+  @spec dense(pos_integer(), pos_integer()) :: LayerConfig.t(Dense)
   def dense(rows, columns) do
-    Dense.build(rows, columns)
+    LayerConfig.build(Dense, rows: rows, columns: columns)
   end
 
   @doc """
@@ -107,17 +117,17 @@ defmodule Annex do
   have no neurons. Upon `Layer.init_layer/2` the Dense layer will be
   initialized with random neurons; Neurons with random weights and biases.
   """
-  @spec dense(pos_integer()) :: Dense.t()
+  @spec dense(pos_integer()) :: LayerConfig.t(Dense)
   def dense(rows) do
-    Dense.build(rows)
+    LayerConfig.build(Dense, rows: rows)
   end
 
   @doc """
   Given an Activation's name returns appropriate `Activation` layer.
   """
-  @spec activation(Activation.func_name()) :: Activation.t()
+  @spec activation(Activation.func_name()) :: LayerConfig.t(Activation)
   def activation(name) do
-    Activation.build(name)
+    LayerConfig.build(Activation, %{name: name})
   end
 
   @doc """

--- a/lib/annex/annex_error.ex
+++ b/lib/annex/annex_error.ex
@@ -23,8 +23,23 @@ defmodule Annex.AnnexError do
 
   defp render_details(details) do
     details
-    |> Enum.map(fn {key, value} ->
-      "#{key}: #{inspect(value)}"
+    |> Enum.map(fn
+      {key, [{subkey, _} | _] = kwargs} when is_atom(subkey) ->
+        value =
+          kwargs
+          |> Enum.map(fn {k, v} ->
+            "  #{k}: #{inspect(v)}"
+          end)
+          |> Enum.intersperse("\n")
+          |> IO.iodata_to_binary()
+
+        "#{key}: [\n#{value}\n]"
+
+      {:code, code} ->
+        "code: #{code}"
+
+      {key, value} ->
+        "#{key}: #{inspect(value)}"
     end)
     |> Enum.intersperse("\n")
     |> IO.iodata_to_binary()

--- a/lib/annex/annex_error.ex
+++ b/lib/annex/annex_error.ex
@@ -1,8 +1,14 @@
 defmodule Annex.AnnexError do
   alias Annex.AnnexError
 
+  @type t :: %__MODULE__{
+          message: String.t(),
+          details: Keyword.t()
+        }
+
   defexception [:message, details: []]
 
+  @spec build(String.t(), Keyword.t()) :: t()
   def build(message, details) do
     %AnnexError{
       message: message,
@@ -10,10 +16,12 @@ defmodule Annex.AnnexError do
     }
   end
 
-  def add_details(%AnnexError{details: prev} = error, details) do
-    %AnnexError{error | details: prev ++ List.wrap(details)}
+  @spec add_details(t(), Keyword.t()) :: t()
+  def add_details(%AnnexError{details: prev} = error, details) when is_list(details) do
+    %AnnexError{error | details: prev ++ details}
   end
 
+  @spec message(t()) :: String.t()
   def message(%AnnexError{message: message, details: details}) do
     """
     #{message}

--- a/lib/annex/layer.ex
+++ b/lib/annex/layer.ex
@@ -18,22 +18,20 @@ defmodule Annex.Layer do
 
   @callback feedforward(t(), Data.data()) :: {struct(), Data.data()}
   @callback backprop(t(), Data.data(), Backprop.t()) :: {t(), Data.data(), Backprop.t()}
-  @callback init_layer(t(), Keyword.t()) :: {:ok, t()} | {:error, any()}
+
+  @callback init_layer(LayerConfig.t()) :: {:ok, struct()} | {:error, AnnexError.t()}
   @callback data_type(t()) :: Data.type() | nil
   @callback shape(t()) :: Shape.t() | nil
-  @callback build(LayerConfig.t()) :: {:ok, struct()} | {:error, AnnexError.t()}
-
-  @optional_callbacks [
-    build: 1,
-    init_layer: 2
-  ]
 
   defmacro __using__(_) do
     quote do
       alias Annex.Layer
       @behaviour Layer
 
-      require Annex.LayerConfig
+      alias Annex.LayerConfig
+      alias Annex.AnnexError
+      require Annex.Utils
+      import Annex.Utils, only: [validate: 3]
     end
   end
 
@@ -47,9 +45,9 @@ defmodule Annex.Layer do
     module.backprop(layer, error, props)
   end
 
-  @spec init_layer(struct(), Keyword.t()) :: {:ok, struct()} | {:error, any()}
-  def init_layer(%module{} = layer, opts) do
-    module.init_layer(layer, opts)
+  @spec init_layer(struct()) :: {:ok, struct()} | {:error, AnnexError.t()}
+  def init_layer(%LayerConfig{} = cfg) do
+    LayerConfig.init_layer(cfg)
   end
 
   @spec data_type(atom | struct()) :: Data.type()

--- a/lib/annex/layer.ex
+++ b/lib/annex/layer.ex
@@ -10,8 +10,8 @@ defmodule Annex.Layer do
     AnnexError,
     Data,
     Data.Shape,
-    LayerConfig,
-    Layer.Backprop
+    Layer.Backprop,
+    LayerConfig
   }
 
   @type t() :: struct()
@@ -28,8 +28,8 @@ defmodule Annex.Layer do
       alias Annex.Layer
       @behaviour Layer
 
-      alias Annex.LayerConfig
       alias Annex.AnnexError
+      alias Annex.LayerConfig
       require Annex.Utils
       import Annex.Utils, only: [validate: 3]
     end

--- a/lib/annex/layer.ex
+++ b/lib/annex/layer.ex
@@ -19,7 +19,7 @@ defmodule Annex.Layer do
   @callback feedforward(t(), Data.data()) :: {struct(), Data.data()}
   @callback backprop(t(), Data.data(), Backprop.t()) :: {t(), Data.data(), Backprop.t()}
 
-  @callback init_layer(LayerConfig.t()) :: {:ok, struct()} | {:error, AnnexError.t()}
+  @callback init_layer(LayerConfig.t(module())) :: {:ok, struct()} | {:error, AnnexError.t()}
   @callback data_type(t()) :: Data.type() | nil
   @callback shape(t()) :: Shape.t() | nil
 

--- a/lib/annex/layer.ex
+++ b/lib/annex/layer.ex
@@ -7,8 +7,10 @@ defmodule Annex.Layer do
   """
 
   alias Annex.{
+    AnnexError,
     Data,
     Data.Shape,
+    LayerConfig,
     Layer.Backprop
   }
 
@@ -19,6 +21,21 @@ defmodule Annex.Layer do
   @callback init_layer(t(), Keyword.t()) :: {:ok, t()} | {:error, any()}
   @callback data_type(t()) :: Data.type() | nil
   @callback shape(t()) :: Shape.t() | nil
+  @callback build(LayerConfig.t()) :: {:ok, struct()} | {:error, AnnexError.t()}
+
+  @optional_callbacks [
+    build: 1,
+    init_layer: 2
+  ]
+
+  defmacro __using__(_) do
+    quote do
+      alias Annex.Layer
+      @behaviour Layer
+
+      require Annex.LayerConfig
+    end
+  end
 
   @spec feedforward(struct(), any()) :: {struct(), any()}
   def feedforward(%module{} = layer, inputs) do

--- a/lib/annex/layer/activation.ex
+++ b/lib/annex/layer/activation.ex
@@ -10,9 +10,9 @@ defmodule Annex.Layer.Activation do
   alias Annex.AnnexError
   alias Annex.Data
   alias Annex.Layer
-  alias Annex.LayerConfig
   alias Annex.Layer.Activation
   alias Annex.Layer.Backprop
+  alias Annex.LayerConfig
 
   @type func_type :: :float | :list
 
@@ -50,7 +50,8 @@ defmodule Annex.Layer.Activation do
   @spec from_name(:relu | :sigmoid | :softmax | :tanh | {:relu, any}) ::
           {:ok, t()} | {:error, AnnexError.t()}
   def from_name(name) do
-    case name do
+    name
+    |> case do
       {:relu, threshold} ->
         %Activation{
           activator: fn n -> max(n, threshold) end,

--- a/lib/annex/layer/activation.ex
+++ b/lib/annex/layer/activation.ex
@@ -40,7 +40,7 @@ defmodule Annex.Layer.Activation do
   ]
 
   @impl Layer
-  @spec init_layer(LayerConfig.t()) :: {:ok, t()} | {:error, AnnexError.t()}
+  @spec init_layer(LayerConfig.t(Activations)) :: {:ok, t()} | {:error, AnnexError.t()}
   def init_layer(%LayerConfig{} = cfg) do
     case LayerConfig.details(cfg) do
       %{name: name} -> from_name(name)

--- a/lib/annex/layer/activation.ex
+++ b/lib/annex/layer/activation.ex
@@ -9,6 +9,7 @@ defmodule Annex.Layer.Activation do
 
   alias Annex.Data
   alias Annex.Layer
+  alias Annex.LayerConfig
   alias Annex.Layer.Activation
   alias Annex.Layer.Backprop
 
@@ -39,8 +40,16 @@ defmodule Annex.Layer.Activation do
     initialized?: false
   ]
 
-  @spec build(:relu | :sigmoid | :tanh | {:relu, number()}) :: t()
-  def build(name) do
+  @impl Layer
+  @spec build(LayerConfig.deatils()) :: t()
+  def build(details) when is_map(details) do
+    case details do
+      %{name: name} -> from_name(name)
+    end
+  end
+
+  @spec from_name(:relu | :sigmoid | :softmax | :tanh | {:relu, any}) :: t()
+  def from_name(name) do
     case name do
       {:relu, threshold} ->
         %Activation{

--- a/lib/annex/layer/dense.ex
+++ b/lib/annex/layer/dense.ex
@@ -9,9 +9,9 @@ defmodule Annex.Layer.Dense do
     Data,
     Data.DMatrix,
     Data.Shape,
-    LayerConfig,
     Layer.Backprop,
     Layer.Dense,
+    LayerConfig,
     Utils
   }
 
@@ -136,7 +136,7 @@ defmodule Annex.Layer.Dense do
           layer_size = rows * columns
           weights_size == layer_size
         end,
-      {:ok, casted_weights} = Data.cast(data_type, weights, {rows, columns})
+      {:ok, casted_weights} <- Data.cast(data_type, weights, {rows, columns})
     ) do
       {:ok, :weights, casted_weights}
     end
@@ -163,7 +163,7 @@ defmodule Annex.Layer.Dense do
 
           biases_rows * biases_columns == rows
         end,
-      {:ok, casted_biases} = Data.cast(data_type, biases, {rows, 1})
+      {:ok, casted_biases} <- Data.cast(data_type, biases, {rows, 1})
     ) do
       {:ok, :biases, casted_biases}
     end

--- a/lib/annex/layer/dense.ex
+++ b/lib/annex/layer/dense.ex
@@ -46,7 +46,7 @@ defmodule Annex.Layer.Dense do
             data_type: nil
 
   @impl Layer
-  @spec init_layer(LayerConfig.t()) :: {:ok, t()} | {:error, AnnexError.t()}
+  @spec init_layer(LayerConfig.t(Dense)) :: {:ok, t()} | {:error, AnnexError.t()}
   def init_layer(%LayerConfig{} = cfg) do
     with(
       {:ok, :data_type, data_type} <- build_data_type(cfg),

--- a/lib/annex/layer/dense.ex
+++ b/lib/annex/layer/dense.ex
@@ -9,7 +9,7 @@ defmodule Annex.Layer.Dense do
     Data,
     Data.DMatrix,
     Data.Shape,
-    Layer,
+    LayerConfig,
     Layer.Backprop,
     Layer.Dense,
     Utils
@@ -17,9 +17,7 @@ defmodule Annex.Layer.Dense do
 
   require Data
 
-  import Annex.Utils, only: [is_pos_integer: 1]
-
-  @behaviour Layer
+  use Annex.Layer
 
   @type data :: Data.data()
 
@@ -30,13 +28,14 @@ defmodule Annex.Layer.Dense do
           rows: pos_integer() | nil,
           columns: pos_integer() | nil,
           input: data() | nil,
-          output: data() | nil,
-          initialized?: boolean()
+          output: data() | nil
         }
 
-  @default_data_type :annex
-                     |> Application.get_env(__MODULE__, [])
-                     |> Keyword.get(:data_type, DMatrix)
+  defp default_data_type do
+    :annex
+    |> Application.get_env(__MODULE__, [])
+    |> Keyword.get(:data_type, DMatrix)
+  end
 
   defstruct weights: nil,
             biases: nil,
@@ -44,20 +43,124 @@ defmodule Annex.Layer.Dense do
             columns: nil,
             input: nil,
             output: nil,
-            initialized?: false,
-            data_type: @default_data_type
+            data_type: nil
 
-  @spec build(pos_integer, pos_integer) :: t()
-  def build(rows, columns) when is_pos_integer(rows) and is_pos_integer(columns) do
-    %Dense{
-      rows: rows,
-      columns: columns
-    }
+  @impl Layer
+  @spec build(LayerConfig.t()) :: {:ok, t()} | {:error, AnnexError.t()}
+  def build(%LayerConfig{} = cfg) do
+    with(
+      {:ok, :data_type, data_type} <- build_data_type(cfg),
+      {:ok, :rows, rows} <- build_rows(cfg),
+      {:ok, :columns, columns} <- build_columns(cfg),
+      {:ok, :weights, weights} <- build_weights(cfg, rows, columns),
+      {:ok, :biases, biases} <- build_biases(cfg, rows)
+    ) do
+      %Dense{
+        biases: Data.cast!(data_type, biases, {rows, 1}),
+        weights: Data.cast!(data_type, weights, {rows, columns}),
+        rows: rows,
+        columns: columns,
+        data_type: data_type
+      }
+    else
+      {:error, _field, error} ->
+        {:error, error}
+    end
   end
 
-  @spec build(pos_integer()) :: t()
-  def build(rows) when is_pos_integer(rows) do
-    %Dense{rows: rows}
+  defp build_rows(cfg) do
+    with(
+      {:ok, :rows, rows} <- LayerConfig.fetch(cfg, :rows),
+      :ok <-
+        LayerConfig.validate :rows, "must be a positive integer" do
+          is_int? = is_integer(rows)
+          is_positive? = rows > 0
+          is_int? && is_positive?
+        end
+    ) do
+      {:ok, :rows, rows}
+    end
+  end
+
+  defp build_columns(cfg) do
+    with(
+      {:ok, :columns, columns} <- LayerConfig.fetch(cfg, :columns),
+      :ok <-
+        LayerConfig.validate :columns, "must be a positive integer" do
+          is_int? = is_integer(columns)
+          is_positive? = columns > 0
+          is_int? && is_positive?
+        end
+    ) do
+      {:ok, :columns, columns}
+    end
+  end
+
+  defp build_data_type(cfg) do
+    with(
+      {:ok, :data_type, data_type} <-
+        LayerConfig.fetch_lazy(cfg, :data_type, fn ->
+          default_data_type()
+        end),
+      :ok <-
+        LayerConfig.validate :data_type, "must be a module" do
+          Utils.is_module?(data_type)
+        end
+    ) do
+      {:ok, :data_type, data_type}
+    end
+  end
+
+  defp build_weights(cfg, rows, columns) do
+    with(
+      {:ok, :weights, weights} <-
+        LayerConfig.fetch_lazy(cfg, :weights, fn ->
+          Utils.random_weights(rows * columns)
+        end),
+      :ok <-
+        LayerConfig.validate :weights, "must be an Annex.Data" do
+          type = Data.infer_type(weights)
+          Data.is_type?(type, weights)
+        end,
+      :ok <-
+        LayerConfig.validate :weights, "shape must be compatible with layer" do
+          {weights_rows, weights_columns} =
+            case Data.shape(weights) do
+              {rows} -> {rows, 1}
+              {rows, cols} -> {rows, cols}
+            end
+
+          weights_rows == rows && weights_columns == columns
+        end
+    ) do
+      {:ok, :weights, weights}
+    end
+  end
+
+  defp build_biases(cfg, rows) do
+    with(
+      {:ok, :biases, biases} <-
+        LayerConfig.fetch_lazy(cfg, :biases, fn ->
+          Utils.ones(rows)
+        end),
+      :ok <-
+        LayerConfig.validate :biases, "must be an Annex.Data" do
+          type = Data.infer_type(biases)
+          Data.is_type?(type, biases)
+        end,
+      :ok <-
+        LayerConfig.validate :biases, "shape must be compatible with layer" do
+          {b_rows, b_columns} =
+            case Data.shape(biases) do
+              {rows} -> {rows, 1}
+              {rows, cols} -> {rows, cols}
+            end
+
+          b_rows == rows && b_columns == 1
+        end
+    ) do
+      {:ok, :biases, biases}
+    end
   end
 
   @spec build(pos_integer, pos_integer, [float, ...], [float, ...]) :: t()
@@ -79,7 +182,7 @@ defmodule Annex.Layer.Dense do
       Data.is_type?(type, weights)
     end
 
-    debug_assert "Dense biases must be a list of floats" do
+    debug_assert "Dense biases must be an Annex.Data" do
       type = Data.infer_type(biases)
       Data.is_type?(type, biases)
     end
@@ -94,14 +197,13 @@ defmodule Annex.Layer.Dense do
       biases_rows == rows && biases_columns == 1
     end
 
-    data_type = Keyword.get(opts, :data_type, @default_data_type)
+    data_type = Keyword.get(opts, :data_type, default_data_type())
 
     %Dense{
       biases: Data.cast!(data_type, biases, {rows, 1}),
       weights: Data.cast!(data_type, weights, {rows, columns}),
       rows: rows,
       columns: columns,
-      initialized?: true,
       data_type: data_type
     }
   end
@@ -120,81 +222,35 @@ defmodule Annex.Layer.Dense do
   @spec columns(t()) :: pos_integer()
   def columns(%Dense{columns: n}), do: n
 
-  @impl Layer
-  @spec init_layer(t(), Keyword.t()) :: {:ok, t()}
-  def init_layer(layer, opts \\ [])
+  # @impl Layer
+  # @spec init_layer(t(), Keyword.t()) :: {:ok, t()}
+  # def init_layer(layer, opts \\ [])
 
-  def init_layer(%Dense{initialized?: true} = layer, _opts) do
-    {:ok, layer}
-  end
+  # def init_layer(%Dense{initialized?: true} = layer, _opts) do
+  #   {:ok, layer}
+  # end
 
-  def init_layer(%Dense{initialized?: false} = dense, opts) do
-    rows = resolve_init_rows(dense, opts)
-    columns = columns(dense)
+  # def init_layer(%Dense{initialized?: false} = dense, opts) do
+  #   rows = resolve_init_rows(dense, opts)
+  #   columns = columns(dense)
 
-    debug_assert "rows is a positive integer" do
-      is_pos_integer(rows) == true
-    end
+  #   debug_assert "rows is a positive integer" do
+  #     is_pos_integer(rows) == true
+  #   end
 
-    debug_assert "columns is a positive integer" do
-      is_pos_integer(rows) == true
-    end
+  #   debug_assert "columns is a positive integer" do
+  #     is_pos_integer(rows) == true
+  #   end
 
-    initialized = %Dense{
-      dense
-      | weights: resolve_init_weights(dense, rows, columns),
-        biases: resolve_init_biases(dense, rows),
-        initialized?: true
-    }
+  #   initialized = %Dense{
+  #     dense
+  #     | weights: resolve_init_weights(dense, rows, columns),
+  #       biases: resolve_init_biases(dense, rows),
+  #       initialized?: true
+  #   }
 
-    {:ok, initialized}
-  end
-
-  defp resolve_init_weights(%Dense{} = dense, rows, columns) do
-    dense
-    |> data_type()
-    |> build_data(get_weights(dense), rows, columns, fn ->
-      Utils.random_weights(rows * columns)
-    end)
-  end
-
-  defp resolve_init_biases(%Dense{} = dense, rows) do
-    dense
-    |> data_type()
-    |> build_data(get_biases(dense), rows, 1, fn ->
-      fn -> 1.0 end
-      |> Stream.repeatedly()
-      |> Enum.take(rows)
-    end)
-  end
-
-  defp build_data(type, data, rows, columns, builder) when is_atom(type) do
-    data = data || builder.()
-    Data.cast!(type, data, {rows, columns})
-  end
-
-  defp resolve_init_rows(%Dense{rows: rows}, _opts) when is_pos_integer(rows) do
-    rows
-  end
-
-  defp resolve_init_rows(%Dense{rows: nil}, opts) do
-    prev_layer = Keyword.get(opts, :prev_layer)
-
-    debug_assert "rows must be specified if there is no previous layer" do
-      prev_layer != nil
-    end
-
-    resolve_init_rows_from_layer(prev_layer)
-  end
-
-  defp resolve_init_rows_from_layer(layer) do
-    layer
-    |> Layer.shape()
-    |> case do
-      {n} when is_pos_integer(n) -> n
-      {n, _} when is_pos_integer(n) -> n
-    end
-  end
+  #   {:ok, initialized}
+  # end
 
   @impl Layer
   @spec feedforward(t(), Data.data()) :: {t(), Data.data()}

--- a/lib/annex/layer/dropout.ex
+++ b/lib/annex/layer/dropout.ex
@@ -25,7 +25,7 @@ defmodule Annex.Layer.Dropout do
   defguard is_frequency(x) when is_float(x) and x >= 0.0 and x <= 1.0
 
   @impl Layer
-  @spec init_layer(LayerConfig.t()) :: {:ok, t()} | {:error, AnnexError.t()}
+  @spec init_layer(LayerConfig.t(Dropout)) :: {:ok, t()} | {:error, AnnexError.t()}
   def init_layer(%LayerConfig{} = cfg) do
     cfg
     |> LayerConfig.details()

--- a/lib/annex/layer/dropout.ex
+++ b/lib/annex/layer/dropout.ex
@@ -12,7 +12,7 @@ defmodule Annex.Layer.Dropout do
     Utils
   }
 
-  @behaviour Layer
+  use Layer
 
   @type t :: %__MODULE__{
           frequency: float()
@@ -24,19 +24,47 @@ defmodule Annex.Layer.Dropout do
 
   defguard is_frequency(x) when is_float(x) and x >= 0.0 and x <= 1.0
 
-  @spec build(float()) :: t()
-  def build(frequency) when is_frequency(frequency) do
-    %Dropout{frequency: frequency}
+  @impl Layer
+  @spec init_layer(LayerConfig.t()) :: {:ok, t()} | {:error, AnnexError.t()}
+  def init_layer(%LayerConfig{} = cfg) do
+    cfg
+    |> LayerConfig.details()
+    |> Map.fetch(:frequency)
+    |> case do
+      {:ok, frequency} when is_frequency(frequency) ->
+        {:ok, %Dropout{frequency: frequency}}
+
+      {:ok, not_frequency} ->
+        error = %AnnexError{
+          message: "Dropout.build/1 requires a :frequency that is a float between 0.0 and 1.0",
+          details: [
+            invalid_frequency: not_frequency,
+            reason: :invalid_frequency_value
+          ]
+        }
+
+        {:error, error}
+
+      :error ->
+        error = %AnnexError{
+          message: "Dropout.build/1 requires a :frequency that is a float between 0.0 and 1.0",
+          details: [
+            reason: {:key_not_found, :frequency}
+          ]
+        }
+
+        {:error, error}
+    end
   end
 
   @spec frequency(t()) :: float()
   def frequency(%Dropout{frequency: f}), do: f
 
-  @impl Layer
-  @spec init_layer(t(), Keyword.t()) :: {:ok, t()}
-  def init_layer(%Dropout{} = dropout, _opts \\ []) do
-    {:ok, dropout}
-  end
+  # @impl Layer
+  # @spec init_layer(t(), Keyword.t()) :: {:ok, t()}
+  # def init_layer(%Dropout{} = dropout, _opts \\ []) do
+  #   {:ok, dropout}
+  # end
 
   @impl Layer
   @spec feedforward(t(), data()) :: {t(), data()}

--- a/lib/annex/layer/lambda.ex
+++ b/lib/annex/layer/lambda.ex
@@ -12,7 +12,6 @@ defmodule Annex.Layer.Lambda do
   alias Annex.{
     Data,
     Data.Shape,
-    Layer,
     Layer.Backprop,
     Layer.Lambda
   }
@@ -52,31 +51,26 @@ defmodule Annex.Layer.Lambda do
     put_state(lambda, state)
   end
 
-  @behaviour Layer
+  # @behaviour Layer
 
-  @impl Layer
   @spec init_layer(t(), Keyword.t()) :: {:ok, t()} | {:error, any()}
   def init_layer(%Lambda{} = lambda, opts \\ []) do
     apply_callback(lambda, :on_init_layer, [lambda, opts], {:ok, lambda})
   end
 
-  @impl Layer
   @spec feedforward(t(), any()) :: {t(), Data.data()}
   def feedforward(%Lambda{} = lambda, inputs) do
     apply_callback(lambda, :on_feedforward, [lambda, inputs], {lambda, inputs})
   end
 
-  @impl Layer
   @spec backprop(t(), Data.data(), Backprop.t()) :: {t(), Data.data(), Backprop.t()}
   def backprop(%Lambda{} = lambda, error, backprop) do
     apply_callback(lambda, :on_backprop, [lambda, error, backprop], {lambda, error, backprop})
   end
 
-  @impl Layer
   @spec data_type(t()) :: Data.type() | nil
   def data_type(%Lambda{data_type: data_type}), do: data_type
 
-  @impl Layer
   @spec shape(t()) :: Shape.t() | nil
   def shape(%Lambda{shape: shape} = lambda) do
     apply_callback(lambda, :on_shape, [lambda], shape)

--- a/lib/annex/layer/sequence.ex
+++ b/lib/annex/layer/sequence.ex
@@ -40,7 +40,7 @@ defmodule Annex.Layer.Sequence do
             cost: Defaults.get_defaults(:cost)
 
   @impl Layer
-  @spec init_layer(LayerConfig.t()) :: {:ok, t()} | {:error, t()}
+  @spec init_layer(LayerConfig.t(Sequence)) :: {:ok, t()} | {:error, AnnexError.t()}
   def init_layer(%LayerConfig{} = cfg) do
     with(
       {:ok, :layers, layer_configs} <- LayerConfig.fetch(cfg, :layers),
@@ -101,7 +101,7 @@ defmodule Annex.Layer.Sequence do
   end
 
   @impl Learner
-  @spec init_learner(t() | LayerConfig.t(), Keyword.t()) :: {:error, any()} | {:ok, t()}
+  @spec init_learner(t() | LayerConfig.t(Sequence), Keyword.t()) :: {:error, any()} | {:ok, t()}
   def init_learner(seq, opts \\ [])
 
   def init_learner(%Sequence{layer_configs: layer_configs}, opts) do

--- a/lib/annex/layer/sequence.ex
+++ b/lib/annex/layer/sequence.ex
@@ -20,7 +20,7 @@ defmodule Annex.Layer.Sequence do
   require Logger
 
   @behaviour Learner
-  @behaviour Layer
+  use Layer
 
   @type layers :: MapArray.t()
 
@@ -33,17 +33,52 @@ defmodule Annex.Layer.Sequence do
         }
 
   defstruct layers: %{},
+            layer_configs: [],
             initialized?: false,
             init_options: [],
             train_options: [],
             cost: Defaults.get_defaults(:cost)
 
-  @spec build(list(Layer.t()), Keyword.t()) :: Sequence.t()
-  def build(layers, _opts \\ []) when is_list(layers) do
-    %Sequence{
-      initialized?: false,
-      layers: MapArray.new(layers)
-    }
+  @impl Layer
+  @spec init_layer(LayerConfig.t()) :: {:ok, t()} | {:error, t()}
+  def init_layer(%LayerConfig{} = cfg) do
+    with(
+      {:ok, :layers, layer_configs} <- LayerConfig.fetch(cfg, :layers),
+      {:ok, layers} <- do_init_layers(layer_configs)
+    ) do
+      {:ok, %Sequence{layers: layers, layer_configs: layer_configs}}
+    else
+      {:error, :layers, %AnnexError{} = err} ->
+        {:error, err}
+
+      {:error, %AnnexError{}} = err ->
+        err
+    end
+  end
+
+  defp do_init_layers(layer_configs) do
+    layer_configs
+    |> Enum.reduce_while([], fn %LayerConfig{} = layer_config, acc ->
+      case LayerConfig.init_layer(layer_config) do
+        {:ok, built_layer} ->
+          {:cont, [built_layer | acc]}
+
+        {:error, _} = error ->
+          {:halt, error}
+      end
+    end)
+    |> case do
+      rev_built_layers when is_list(rev_built_layers) ->
+        built_layers =
+          rev_built_layers
+          |> Enum.reverse()
+          |> MapArray.new()
+
+        {:ok, built_layers}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   @spec add_layer(t(), struct()) :: t()
@@ -66,53 +101,61 @@ defmodule Annex.Layer.Sequence do
   end
 
   @impl Learner
-  @spec init_learner(t(), any()) :: {:error, any()} | {:ok, t()}
-  def init_learner(seq, opts \\ []) do
-    init_layer(seq, opts)
+  @spec init_learner(t() | LayerConfig.t(), Keyword.t()) :: {:error, any()} | {:ok, t()}
+  def init_learner(seq, opts \\ [])
+
+  def init_learner(%Sequence{layer_configs: layer_configs}, opts) do
+    Sequence
+    |> LayerConfig.build(layers: layer_configs)
+    |> init_learner(opts)
+  end
+
+  def init_learner(%LayerConfig{} = cfg, _opts) do
+    init_layer(cfg)
   end
 
   @impl Layer
   @spec data_type(t()) :: DMatrix
   def data_type(_), do: DMatrix
 
-  @impl Layer
-  @spec init_layer(Sequence.t(), any()) :: {:error, any()} | {:ok, Sequence.t()}
-  def init_layer(seq, opts \\ [])
+  # @impl Layer
+  # @spec init_layer(Sequence.t(), any()) :: {:error, any()} | {:ok, Sequence.t()}
+  # def init_layer(seq, opts \\ [])
 
-  def init_layer(%Sequence{initialized?: true} = seq, _opts) do
-    {:ok, seq}
-  end
+  # def init_layer(%Sequence{initialized?: true} = seq, _opts) do
+  #   {:ok, seq}
+  # end
 
-  def init_layer(%Sequence{initialized?: false} = seq1, _opts) do
-    initialized_layers =
-      seq1
-      |> get_layers()
-      |> MapArray.map(fn layer, i ->
-        case Layer.init_layer(layer, []) do
-          {:ok, layer} ->
-            {i, layer}
+  # def init_layer(%Sequence{initialized?: false} = seq1, _opts) do
+  #   initialized_layers =
+  #     seq1
+  #     |> get_layers()
+  #     |> MapArray.map(fn layer, i ->
+  #       case Layer.init_layer(layer, []) do
+  #         {:ok, layer} ->
+  #           {i, layer}
 
-          err ->
-            raise Annex.AnnexError,
-              message: """
-              Annex.Layer.Sequence failed to initialize layer.
+  #         err ->
+  #           raise Annex.AnnexError,
+  #             message: """
+  #             Annex.Layer.Sequence failed to initialize layer.
 
-              error: #{inspect(err)}
-              layer: #{inspect(layer)}
-              sequence: #{inspect(seq1)}
-              """
-        end
-      end)
-      |> Map.new()
+  #             error: #{inspect(err)}
+  #             layer: #{inspect(layer)}
+  #             sequence: #{inspect(seq1)}
+  #             """
+  #       end
+  #     end)
+  #     |> Map.new()
 
-    initialized_seq = %Sequence{
-      seq1
-      | layers: initialized_layers,
-        initialized?: true
-    }
+  #   initialized_seq = %Sequence{
+  #     seq1
+  #     | layers: initialized_layers,
+  #       initialized?: true
+  #   }
 
-    {:ok, initialized_seq}
-  end
+  #   {:ok, initialized_seq}
+  # end
 
   @impl Layer
   @spec feedforward(Sequence.t(), Data.data()) :: {Sequence.t(), Data.data()}

--- a/lib/annex/layer_config.ex
+++ b/lib/annex/layer_config.ex
@@ -1,0 +1,97 @@
+defmodule Annex.LayerConfig do
+  alias Annex.{
+    AnnexError,
+    LayerConfig
+  }
+
+  @type details :: %{atom() => any}
+  @type t :: %__MODULE__{
+          details: details(),
+          module: module()
+        }
+
+  defstruct details: %{},
+            module: nil
+
+  def build(module, kvs \\ []) when is_atom(module) do
+    %LayerConfig{
+      module: module,
+      details: Map.new(kvs)
+    }
+  end
+
+  @spec module(t()) :: module()
+  def module(%LayerConfig{module: m}), do: m
+
+  def details(%LayerConfig{details: d}), do: d
+
+  @spec add(t(), atom(), any()) :: t()
+  def add(cfg, key, value) do
+    add(cfg, %{key => value})
+  end
+
+  @spec add(t(), any) :: t()
+  def add(%LayerConfig{} = cfg, details) do
+    more_details = Map.new(details)
+    %LayerConfig{cfg | details: cfg |> details |> Map.merge(more_details)}
+  end
+
+  def build_layer(%LayerConfig{} = cfg) do
+    module(cfg).build(cfg)
+  end
+
+  def fetch(%LayerConfig{} = cfg, key) do
+    cfg
+    |> details()
+    |> Map.fetch(key)
+    |> case do
+      {:ok, value} ->
+        {:ok, key, value}
+
+      :error ->
+        error = %AnnexError{
+          message: "is required",
+          details: [
+            key: key,
+            layer_module: module(cfg)
+          ]
+        }
+
+        {:error, key, error}
+    end
+  end
+
+  def fetch_lazy(%LayerConfig{} = cfg, key, func) when is_function(func, 0) do
+    case fetch(cfg, key) do
+      {:ok, _, _} = found ->
+        found
+
+      {:error, key, _} ->
+        {:ok, key, func.()}
+    end
+  end
+
+  defmacro validate(field, reason, do: expr) do
+    code = Macro.to_string(expr)
+    vars = Annex.Debug.get_ast_vars(expr)
+
+    quote do
+      result = unquote(expr)
+
+      if result != true do
+        error = %Annex.AnnexError{
+          message: "valiation failed",
+          details: [
+            reason: unquote(reason),
+            code: unquote(code),
+            variables: Keyword.take(binding(), unquote(vars))
+          ]
+        }
+
+        {:error, unquote(field), error}
+      else
+        :ok
+      end
+    end
+  end
+end

--- a/lib/annex/layer_config.ex
+++ b/lib/annex/layer_config.ex
@@ -1,4 +1,10 @@
 defmodule Annex.LayerConfig do
+  @moduledoc """
+  The Annex.LayerConfig is the intermediate structure used to intialize an Annex.Layer.
+
+  This is particularly useful for building the same Layer given many different combinations
+  of configuration.
+  """
   alias Annex.{
     AnnexError,
     LayerConfig

--- a/lib/annex/utils.ex
+++ b/lib/annex/utils.ex
@@ -22,6 +22,12 @@ defmodule Annex.Utils do
     Enum.map(1..n, fn _ -> random_float() end)
   end
 
+  def ones(n) do
+    fn -> 1.0 end
+    |> Stream.repeatedly()
+    |> Enum.take(n)
+  end
+
   @doc """
   Random unifmormly splits a given `dataset` into two datasets at a given `frequency`.
   """
@@ -136,5 +142,9 @@ defmodule Annex.Utils do
       0.0 -> Enum.map(data, fn item -> item end)
       sum -> Enum.map(data, fn item -> item / sum end)
     end
+  end
+
+  def is_module?(item) do
+    is_atom(item) && Code.ensure_loaded?(item)
   end
 end

--- a/lib/annex/utils.ex
+++ b/lib/annex/utils.ex
@@ -147,4 +147,30 @@ defmodule Annex.Utils do
   def is_module?(item) do
     is_atom(item) && Code.ensure_loaded?(item)
   end
+
+  defmacro validate(field, reason, do: expr) do
+    code = Macro.to_string(expr)
+    vars = Annex.Debug.get_ast_vars(expr)
+
+    quote do
+      result = unquote(expr)
+
+      if result != true do
+        error = %Annex.AnnexError{
+          message: "valiation failed",
+          details: [
+            module: __MODULE__,
+            field: unquote(field),
+            reason: unquote(reason),
+            variables: Keyword.take(binding(), unquote(vars)),
+            code: unquote(code)
+          ]
+        }
+
+        {:error, unquote(field), error}
+      else
+        :ok
+      end
+    end
+  end
 end

--- a/test/annex/data_test.exs
+++ b/test/annex/data_test.exs
@@ -40,10 +40,7 @@ defmodule Annex.DataTest do
   ]
 
   use Annex.DataCase, type: SimpleData, data: @casts
-
-  # test "type behaviour is correctly implemented" do
-  #   Annex.DataCase.run_all_assertions(SimpleData, @casts)
-  # end
+  use Annex.LayerCase
 
   describe "cast/3" do
     test "calls cast for implementers of behaviour" do
@@ -137,14 +134,14 @@ defmodule Annex.DataTest do
     end
 
     test "works for Layer" do
-      dense = Dense.build(2, 3)
+      assert {:ok, %Dense{} = dense} = build(Dense, rows: 2, columns: 3)
       assert Data.infer_type(dense) == DMatrix
     end
   end
 
   describe "data_type/1" do
-    test "a Dense layer struct has a default data_type" do
-      dense = %Dense{}
+    test "a built Dense layer defaults data_type to DMatrix" do
+      dense = build!(Dense, rows: 3, columns: 2)
       assert %Dense{data_type: DMatrix} = dense
     end
   end

--- a/test/annex/layer/activation_test.exs
+++ b/test/annex/layer/activation_test.exs
@@ -3,17 +3,6 @@ defmodule Annex.Layer.ActivationTest do
 
   alias Annex.Layer.Activation
 
-  describe "init_layer/2" do
-    test "turns initialized? from false to true" do
-      activation1 = Activation.build(:sigmoid)
-      assert %Activation{initialized?: false} = activation1
-
-      opts = []
-      assert {:ok, activation2} = Activation.init_layer(activation1, opts)
-      assert %Activation{initialized?: true} = activation2
-    end
-  end
-
   test "relu/1" do
     assert Activation.relu(1.0) == 1.0
     assert Activation.relu(0.5) == 0.5

--- a/test/annex/layer/dense_test.exs
+++ b/test/annex/layer/dense_test.exs
@@ -1,5 +1,5 @@
 defmodule Annex.Layer.DenseTest do
-  use ExUnit.Case, async: true
+  use Annex.LayerCase, async: true
 
   alias Annex.{
     Cost,
@@ -15,7 +15,7 @@ defmodule Annex.Layer.DenseTest do
   def fixture do
     weights = [-0.3333, 0.24, 0.1, 0.7, -0.4, -0.9]
     biases = [1.0, 1.0]
-    Dense.build(2, 3, weights, biases)
+    build!(Dense, rows: 2, columns: 3, weights: weights, baises: biases)
   end
 
   test "dense feedforward works" do
@@ -107,24 +107,45 @@ defmodule Annex.Layer.DenseTest do
            }
   end
 
-  @dense_2_by_3 Dense.build(2, 3, [1.0, 1.0, 1.0, 0.5, 0.5, 0.5], [1.0, 1.0])
+  @dense_2_by_3 build!(Dense,
+                  rows: 2,
+                  columns: 3,
+                  weights: [1.0, 1.0, 1.0, 0.5, 0.5, 0.5],
+                  biases: [1.0, 1.0]
+                )
+  describe "init_layer/1" do
+    test "ok for valid config with rows and columns" do
+      assert {:ok, %Dense{}} =
+               Dense
+               |> LayerConfig.build(rows: 2, columns: 3)
+               |> Dense.init_layer()
+    end
 
-  describe "build/4" do
-    test "outputs the correct shape" do
-      built = Dense.build(2, 3, [1.0, 1.0, 1.0, 0.5, 0.5, 0.5], [1.0, 1.0])
+    test "ok for valid rows, columns, weights, and biases" do
+      assert {:ok, dense} =
+               Dense
+               |> LayerConfig.build(
+                 rows: 2,
+                 columns: 3,
+                 weights: [1.0, 1.0, 1.0, 0.5, 0.5, 0.5],
+                 biases: [1.0, 1.0]
+               )
+               |> Dense.init_layer()
 
-      assert built == %Dense{
-               weights: DMatrix.build([[1.0, 1.0, 1.0], [0.5, 0.5, 0.5]]),
-               biases: DMatrix.build([[1.0], [1.0]]),
+      assert %Dense{
+               weights: weights,
+               biases: biases,
                rows: 2,
                columns: 3,
-               initialized?: true
-             }
+               data_type: Annex.Data.DMatrix
+             } = dense
 
-      dense = Dense.build(2, 1, [1.0, 1.0], [1.0, 1.0])
-      assert dense.weights == DMatrix.build([[1.0], [1.0]])
-      assert Data.shape(DMatrix, dense.weights) == {2, 1}
-      assert Dense.shape(dense) == {2, 1}
+      assert weights == DMatrix.build([[1.0, 1.0, 1.0], [0.5, 0.5, 0.5]])
+      assert biases == DMatrix.build([[1.0], [1.0]])
+
+      assert Data.shape(weights) == {2, 3}
+      assert Data.shape(biases) == {2, 1}
+      assert Dense.shape(dense) == {2, 3}
     end
   end
 

--- a/test/annex/layer/dropout_test.exs
+++ b/test/annex/layer/dropout_test.exs
@@ -1,27 +1,51 @@
 defmodule Annex.Layer.DropoutTest do
-  use ExUnit.Case
+  use Annex.LayerCase
 
   alias Annex.{
+    AnnexError,
     Layer,
+    LayerConfig,
     Layer.Dropout
   }
 
-  describe "build/1" do
+  describe "init_layer/1" do
+    test "ok for valid config" do
+      cfg = LayerConfig.build(Dropout, frequency: 0.5)
+      {:ok, layer} = Layer.init_layer(cfg)
+      assert %Dropout{frequency: 0.5} == layer
+    end
+
+    test "error for invalid config" do
+      cfg = LayerConfig.build(Dropout, frequency: 1.5)
+      {:error, error} = Layer.init_layer(cfg)
+      message = "Dropout.build/1 requires a :frequency that is a float between 0.0 and 1.0"
+
+      assert error == %AnnexError{
+               message: message,
+               details: [
+                 invalid_frequency: 1.5,
+                 reason: :invalid_frequency_value
+               ]
+             }
+    end
+
     test "works for frequency above 0.0 and less than or equal to 1.0" do
-      assert %Dropout{frequency: 1.0} = Dropout.build(1.0)
-      assert %Dropout{frequency: 0.444} = Dropout.build(0.444)
-      assert %Dropout{frequency: 0.0} = Dropout.build(0.0)
+      assert {:ok, _} = build(Dropout, frequency: 1.0)
+      assert {:ok, _} = build(Dropout, frequency: 0.444)
+      assert {:ok, _} = build(Dropout, frequency: 0.0)
     end
 
-    test "raises for non-frequency" do
-      assert_raise(FunctionClauseError, fn -> Dropout.build(1.1) end)
-      assert_raise(FunctionClauseError, fn -> Dropout.build(1) end)
-      assert_raise(FunctionClauseError, fn -> Dropout.build(:one) end)
-      assert_raise(FunctionClauseError, fn -> Dropout.build(-1.0) end)
+    test "errors for non-frequency" do
+      assert {:error, %AnnexError{}} = build(Dropout, frequency: 1.1)
+      assert {:error, %AnnexError{}} = build(Dropout, frequency: 1)
+      assert {:error, %AnnexError{}} = build(Dropout, frequency: :one)
+      assert {:error, %AnnexError{}} = build(Dropout, frequency: -1.0)
     end
+  end
 
-    test "dropout can handle a list of floats" do
-      layer1 = Dropout.build(0.5)
+  describe "feedforward/2" do
+    test "works with a list of floats" do
+      layer1 = build!(Dropout, frequency: 0.5)
       original = 0.666
       {_layer2, pred} = Layer.feedforward(layer1, [original])
       assert [zeroed_or_original] = pred
@@ -29,16 +53,9 @@ defmodule Annex.Layer.DropoutTest do
     end
 
     test "dropout does not change on feedforward" do
-      layer1 = Dropout.build(0.5)
+      layer1 = build!(Dropout, frequency: 0.5)
       {layer2, _pred} = Layer.feedforward(layer1, [1.0])
       assert layer1 == layer2
-    end
-
-    test "dropout does not change on init_layer" do
-      opts = []
-      layer1 = Dropout.build(0.5)
-      {:ok, layer2} = Layer.init_layer(layer1, opts)
-      assert layer2 == layer1
     end
   end
 end

--- a/test/annex/layer/dropout_test.exs
+++ b/test/annex/layer/dropout_test.exs
@@ -4,8 +4,8 @@ defmodule Annex.Layer.DropoutTest do
   alias Annex.{
     AnnexError,
     Layer,
-    LayerConfig,
-    Layer.Dropout
+    Layer.Dropout,
+    LayerConfig
   }
 
   describe "init_layer/1" do

--- a/test/annex/layer_test.exs
+++ b/test/annex/layer_test.exs
@@ -1,5 +1,5 @@
 defmodule Annex.LayerTest do
-  use ExUnit.Case
+  use Annex.LayerCase
 
   alias Annex.{
     Layer,
@@ -9,7 +9,7 @@ defmodule Annex.LayerTest do
   def dense_fixture do
     weights = [-0.3333, 0.24, 0.1, 0.7, -0.4, -0.9]
     biases = [1.0, 1.0]
-    Dense.build(2, 3, weights, biases)
+    build!(Dense, rows: 2, columns: 3, weights: weights, biases: biases)
   end
 
   describe "forward_shape/1" do

--- a/test/layer_config_test.exs
+++ b/test/layer_config_test.exs
@@ -1,0 +1,140 @@
+defmodule Annex.LayerConfigTest do
+  use ExUnit.Case
+
+  alias Annex.{
+    AnnexError,
+    LayerConfig
+  }
+
+  defmodule Thing do
+    defstruct name: nil
+
+    def init_layer(%LayerConfig{} = cfg) do
+      case LayerConfig.fetch(cfg, :name) do
+        {:ok, :name, name} ->
+          {:ok, %Thing{name: name}}
+
+        {:error, %AnnexError{}} = error ->
+          error
+      end
+    end
+  end
+
+  test "struct defaults are correct" do
+    assert %LayerConfig{} == %LayerConfig{
+             module: nil,
+             details: %{}
+           }
+  end
+
+  describe "build/1" do
+    test "works with a module" do
+      assert %LayerConfig{module: Thing} = LayerConfig.build(Thing)
+    end
+  end
+
+  describe "build/2" do
+    test "first arg becomes the module" do
+      assert %LayerConfig{module: Thing} = LayerConfig.build(Thing, [])
+    end
+
+    test "second arg can be a keyword" do
+      assert %LayerConfig{
+               module: Thing,
+               details: %{
+                 name: "Jason"
+               }
+             } = LayerConfig.build(Thing, name: "Jason")
+    end
+
+    test "second arg can be a map" do
+      assert %LayerConfig{
+               module: Thing,
+               details: %{
+                 name: "Jason"
+               }
+             } = LayerConfig.build(Thing, %{name: "Jason"})
+    end
+
+    test "raises for non-keyword|map for second arg" do
+      # string not an enumerable
+      assert_raise(Protocol.UndefinedError, fn ->
+        LayerConfig.build(Thing, "name: Jason")
+      end)
+
+      # list is an enumerable, but not a key-value collection
+      assert_raise(ArgumentError, fn ->
+        LayerConfig.build(Thing, ["name: Jason"])
+      end)
+    end
+  end
+
+  describe "module/1" do
+    test "returns the :module field" do
+      cfg = %LayerConfig{
+        module: Thing
+      }
+
+      assert LayerConfig.module(cfg) == Thing
+    end
+  end
+
+  describe "details/1" do
+    test "returns the :details field" do
+      cfg = %LayerConfig{
+        details: %{name: "blep"}
+      }
+
+      assert LayerConfig.details(cfg) == %{name: "blep"}
+    end
+  end
+
+  describe "add/3" do
+    test "adds a key and value to the LayerConfig details" do
+      assert LayerConfig.add(%LayerConfig{}, :name, "Jason") == %LayerConfig{
+               details: %{
+                 name: "Jason"
+               }
+             }
+    end
+  end
+
+  describe "add/2" do
+    test "merges a map or keyword of details into the details of a LayerConfig" do
+      cfg = %LayerConfig{details: %{name: "Jason"}}
+      cfg2 = LayerConfig.add(cfg, %{name: "Jason2", other: "yep"})
+
+      assert cfg2 == %LayerConfig{
+               details: %{name: "Jason2", other: "yep"}
+             }
+    end
+  end
+
+  describe "init_layer/1" do
+    test "{:ok Layer.t()} for valid config" do
+      cfg = LayerConfig.build(Thing, name: "Jason2")
+      assert {:ok, thing} = LayerConfig.init_layer(cfg)
+      assert thing == %Thing{name: "Jason2"}
+    end
+  end
+
+  describe "fetch/2" do
+    test "{:ok, key value} for an existing detail" do
+      cfg = LayerConfig.build(Thing, name: "Jason2")
+      assert {:ok, :name, "Jason2"} = LayerConfig.fetch(cfg, :name)
+    end
+
+    test "{:error, annex_error} for a non-existing detail" do
+      cfg = LayerConfig.build(Thing, name: "Jason2")
+      assert {:error, :not_a_key, %AnnexError{}} = LayerConfig.fetch(cfg, :not_a_key)
+    end
+  end
+
+  describe "fetch_lazy/3" do
+    test "returns {:ok, key, found_value} or {:ok, key, func_result}" do
+      cfg = LayerConfig.build(Thing, name: "Jason2")
+      {:ok, :name, "Jason2"} = LayerConfig.fetch_lazy(cfg, :name, fn -> "other" end)
+      {:ok, :not_name, "other"} = LayerConfig.fetch_lazy(cfg, :not_name, fn -> "other" end)
+    end
+  end
+end

--- a/test/support/layer_case.ex
+++ b/test/support/layer_case.ex
@@ -1,0 +1,10 @@
+defmodule Annex.LayerCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import Annex.LayerHelpers
+      alias Annex.LayerConfig
+    end
+  end
+end

--- a/test/support/layer_case.ex
+++ b/test/support/layer_case.ex
@@ -1,4 +1,7 @@
 defmodule Annex.LayerCase do
+  @moduledoc """
+  Imports LayerHelpers and aliases LayerConfig.
+  """
   use ExUnit.CaseTemplate
 
   using do

--- a/test/support/layer_helpers.ex
+++ b/test/support/layer_helpers.ex
@@ -1,0 +1,29 @@
+defmodule Annex.LayerHelpers do
+  alias Annex.{
+    AnnexError,
+    LayerConfig
+  }
+
+  @type kvs :: map | keyword()
+
+  @spec build(atom, kvs) :: struct()
+  def build(module, kvs) do
+    module
+    |> LayerConfig.build(kvs)
+    |> LayerConfig.init_layer()
+  end
+
+  @spec build!(atom, any) :: Layer.t()
+  def build!(module, kvs) do
+    module
+    |> LayerConfig.build(kvs)
+    |> LayerConfig.init_layer()
+    |> case do
+      {:ok, layer} ->
+        layer
+
+      {:error, %AnnexError{} = error} ->
+        raise error
+    end
+  end
+end

--- a/test/support/layer_helpers.ex
+++ b/test/support/layer_helpers.ex
@@ -1,4 +1,7 @@
 defmodule Annex.LayerHelpers do
+  @moduledoc """
+  Helpers for building Layers.
+  """
   alias Annex.{
     AnnexError,
     LayerConfig
@@ -6,7 +9,7 @@ defmodule Annex.LayerHelpers do
 
   @type kvs :: map | keyword()
 
-  @spec build(atom, kvs) :: struct()
+  @spec build(atom, kvs) :: {:ok, struct()} | {:error, AnnexError.t()}
   def build(module, kvs) do
     module
     |> LayerConfig.build(kvs)


### PR DESCRIPTION
This PR adds `LayerConfig` which gives `Annex` the ability to separate the instructions for building a layer or network from the **actual** network or layer.

This is very useful for at least two reasons:

1) There is no longer any reason to represent Layers in partially built states (e.g. `weights` of `Dense` being type `nil | Data.data` will become `Data.data`.
2) Some backends (tensorflow, Keras, etc.) require a configuration then compilation. LayerConfig let's us define the intended configuration of such a network. A network would be laid out in LayerConfigs, those LayerConfigs would be passed into the `init_layer` which would compile the backend and return an appropriate Layer struct.