### PR TITLE
Add Annex.Optimizer behavoiur and Annex.Optimizer.SGD

### DIFF
--- a/lib/annex/data.ex
+++ b/lib/annex/data.ex
@@ -53,7 +53,7 @@ defmodule Annex.Data do
   """
 
   def cast(type, data, []) when is_list(data) do
-    message = "Annex.Data.cast/3 got an list for shape"
+    message = "Annex.Data.cast/3 got an empty list for shape"
     error = AnnexError.build(message, type: type, data: data)
     {:error, error}
   end
@@ -195,5 +195,14 @@ defmodule Annex.Data do
   @spec apply_op(module, data(), any, list(any)) :: data()
   def apply_op(type, data, name, args) when is_atom(type) do
     type.apply_op(data, name, args)
+  end
+
+  @spec error(Data.data(), Data.data()) :: Data.flat_data()
+  def error(outputs, labels) do
+    labels = Data.to_flat_list(labels)
+
+    outputs
+    |> Data.to_flat_list()
+    |> Data.apply_op(:subtract, [labels])
   end
 end

--- a/lib/annex/dataset.ex
+++ b/lib/annex/dataset.ex
@@ -1,0 +1,34 @@
+defmodule Annex.Dataset do
+  @moduledoc """
+  A
+  """
+  alias Annex.{Data, Utils}
+
+  @type inputs :: Data.data()
+  @type labels :: Data.data()
+  @type row :: {inputs(), labels()}
+  @type t :: [row(), ...]
+
+  def zip(inputs, labels) do
+    Utils.zip(inputs, labels)
+  end
+
+  def randomize(dataset) do
+    Enum.shuffle(dataset)
+  end
+
+  @doc """
+  Random unifmormly splits a given `dataset` into two datasets at a given `frequency`.
+
+  Very useful for splitting traiings
+  """
+  def split(dataset, frequency) when frequency >= 0.0 and frequency <= 1.0 do
+    %{true => left, false => right} =
+      dataset
+      |> randomize()
+      |> Enum.group_by(fn _ -> :rand.uniform() > frequency end)
+      |> Enum.into(%{true => [], false => []})
+
+    {left, right}
+  end
+end

--- a/lib/annex/layer.ex
+++ b/lib/annex/layer.ex
@@ -69,13 +69,13 @@ defmodule Annex.Layer do
   def has_shapes?(%module{}), do: has_shapes?(module)
   def has_shapes?(module) when is_atom(module), do: function_exported?(module, :shapes, 1)
 
-  @spec is_layer?(module() | struct()) :: boolean()
+  @spec is_layer?(any()) :: boolean()
   def is_layer?(%module{}) do
     is_layer?(module)
   end
 
-  def is_layer?(module) when is_atom(module) do
-    function_exported?(module, :__annex__, 1) && module.__annex__(:is_layer?)
+  def is_layer?(item) do
+    is_atom(item) && function_exported?(item, :__annex__, 1) && item.__annex__(:is_layer?)
   end
 
   def input_shape(layer) do

--- a/lib/annex/layer.ex
+++ b/lib/annex/layer.ex
@@ -7,7 +7,6 @@ defmodule Annex.Layer do
   """
 
   alias Annex.{
-    AnnexError,
     Data,
     Layer.Backprop,
     LayerConfig,
@@ -19,7 +18,7 @@ defmodule Annex.Layer do
   @callback feedforward(t(), Data.data()) :: {struct(), Data.data()}
   @callback backprop(t(), Data.data(), Backprop.t()) :: {t(), Data.data(), Backprop.t()}
 
-  @callback init_layer(LayerConfig.t(module())) :: {:ok, struct()} | {:error, AnnexError.t()}
+  @callback init_layer(LayerConfig.t(module())) :: t()
 
   @callback data_type(t()) :: Data.type()
   @callback shapes(t()) :: {Shape.t(), Shape.t()}
@@ -38,6 +37,8 @@ defmodule Annex.Layer do
       alias Annex.LayerConfig
       require Annex.Utils
       import Annex.Utils, only: [validate: 3]
+
+      def __annex__(:is_layer?), do: true
     end
   end
 
@@ -51,10 +52,8 @@ defmodule Annex.Layer do
     module.backprop(layer, error, props)
   end
 
-  @spec init_layer(struct()) :: {:ok, struct()} | {:error, AnnexError.t()}
-  def init_layer(%LayerConfig{} = cfg) do
-    LayerConfig.init_layer(cfg)
-  end
+  @spec init_layer(LayerConfig.t()) :: t()
+  def init_layer(%LayerConfig{} = cfg), do: LayerConfig.init_layer(cfg)
 
   @spec has_data_type?(module() | struct()) :: boolean()
   def has_data_type?(%module{}), do: has_data_type?(module)
@@ -69,6 +68,15 @@ defmodule Annex.Layer do
   @spec has_shapes?(module() | struct()) :: boolean()
   def has_shapes?(%module{}), do: has_shapes?(module)
   def has_shapes?(module) when is_atom(module), do: function_exported?(module, :shapes, 1)
+
+  @spec is_layer?(module() | struct()) :: boolean()
+  def is_layer?(%module{}) do
+    is_layer?(module)
+  end
+
+  def is_layer?(module) when is_atom(module) do
+    function_exported?(module, :__annex__, 1) && module.__annex__(:is_layer?)
+  end
 
   def input_shape(layer) do
     if has_shapes?(layer) do

--- a/lib/annex/layer.ex
+++ b/lib/annex/layer.ex
@@ -52,7 +52,7 @@ defmodule Annex.Layer do
     module.backprop(layer, error, props)
   end
 
-  @spec init_layer(LayerConfig.t()) :: t()
+  @spec init_layer(LayerConfig.t(module())) :: t()
   def init_layer(%LayerConfig{} = cfg), do: LayerConfig.init_layer(cfg)
 
   @spec has_data_type?(module() | struct()) :: boolean()

--- a/lib/annex/layer/activation.ex
+++ b/lib/annex/layer/activation.ex
@@ -39,15 +39,14 @@ defmodule Annex.Layer.Activation do
   ]
 
   @impl Layer
-  @spec init_layer(LayerConfig.t(Activations)) :: {:ok, t()} | {:error, AnnexError.t()}
+  @spec init_layer(LayerConfig.t(Activations)) :: t()
   def init_layer(%LayerConfig{} = cfg) do
     case LayerConfig.details(cfg) do
       %{name: name} -> from_name(name)
     end
   end
 
-  @spec from_name(:relu | :sigmoid | :softmax | :tanh | {:relu, any}) ::
-          {:ok, t()} | {:error, AnnexError.t()}
+  @spec from_name(func_name()) :: t() | no_return()
   def from_name(name) do
     name
     |> case do
@@ -92,21 +91,12 @@ defmodule Annex.Layer.Activation do
         }
 
       _ ->
-        :error
-    end
-    |> case do
-      %Activation{} = layer ->
-        {:ok, layer}
-
-      :error ->
-        error = %AnnexError{
+        raise %AnnexError{
           message: "unknown activation name",
           details: [
             name: name
           ]
         }
-
-        {:error, error}
     end
   end
 

--- a/lib/annex/layer/dense.ex
+++ b/lib/annex/layer/dense.ex
@@ -46,7 +46,7 @@ defmodule Annex.Layer.Dense do
             data_type: nil
 
   @impl Layer
-  @spec init_layer(LayerConfig.t(Dense)) :: {:ok, t()} | {:error, AnnexError.t()}
+  @spec init_layer(LayerConfig.t(Dense)) :: t() | no_return()
   def init_layer(%LayerConfig{} = cfg) do
     with(
       {:ok, :data_type, data_type} <- build_data_type(cfg),
@@ -55,18 +55,16 @@ defmodule Annex.Layer.Dense do
       {:ok, :weights, weights} <- build_weights(cfg, data_type, rows, columns),
       {:ok, :biases, biases} <- build_biases(cfg, data_type, rows)
     ) do
-      dense = %Dense{
+      %Dense{
         biases: biases,
         weights: weights,
         rows: rows,
         columns: columns,
         data_type: data_type
       }
-
-      {:ok, dense}
     else
       {:error, _field, error} ->
-        {:error, error}
+        raise error
     end
   end
 

--- a/lib/annex/layer/dropout.ex
+++ b/lib/annex/layer/dropout.ex
@@ -25,17 +25,17 @@ defmodule Annex.Layer.Dropout do
   defguard is_frequency(x) when is_float(x) and x >= 0.0 and x <= 1.0
 
   @impl Layer
-  @spec init_layer(LayerConfig.t(Dropout)) :: {:ok, t()} | {:error, AnnexError.t()}
+  @spec init_layer(LayerConfig.t(Dropout)) :: t()
   def init_layer(%LayerConfig{} = cfg) do
     cfg
     |> LayerConfig.details()
     |> Map.fetch(:frequency)
     |> case do
       {:ok, frequency} when is_frequency(frequency) ->
-        {:ok, %Dropout{frequency: frequency}}
+        %Dropout{frequency: frequency}
 
       {:ok, not_frequency} ->
-        error = %AnnexError{
+        raise %AnnexError{
           message: "Dropout.build/1 requires a :frequency that is a float between 0.0 and 1.0",
           details: [
             invalid_frequency: not_frequency,
@@ -43,17 +43,13 @@ defmodule Annex.Layer.Dropout do
           ]
         }
 
-        {:error, error}
-
       :error ->
-        error = %AnnexError{
+        raise %AnnexError{
           message: "Dropout.build/1 requires a :frequency that is a float between 0.0 and 1.0",
           details: [
             reason: {:key_not_found, :frequency}
           ]
         }
-
-        {:error, error}
     end
   end
 

--- a/lib/annex/layer_config.ex
+++ b/lib/annex/layer_config.ex
@@ -7,6 +7,7 @@ defmodule Annex.LayerConfig do
   """
   alias Annex.{
     AnnexError,
+    Layer,
     LayerConfig
   }
 
@@ -42,7 +43,7 @@ defmodule Annex.LayerConfig do
     %LayerConfig{cfg | details: cfg |> details |> Map.merge(more_details)}
   end
 
-  @spec init_layer(t(module())) :: {:ok, struct()} | {:error, AnnexError.t()}
+  @spec init_layer(t(module())) :: Layer.t()
   def init_layer(%LayerConfig{} = cfg) do
     module(cfg).init_layer(cfg)
   end

--- a/lib/annex/learner.ex
+++ b/lib/annex/learner.ex
@@ -7,6 +7,7 @@ defmodule Annex.Learner do
 
   alias Annex.{
     Data,
+    Dataset,
     LayerConfig,
     Optimizer,
     Optimizer.SGD
@@ -31,7 +32,7 @@ defmodule Annex.Learner do
     init_learner: 2
   ]
 
-  def __using__(_) do
+  defmacro __using__(_) do
     quote do
       def __annex__(:learner?), do: true
 
@@ -39,7 +40,7 @@ defmodule Annex.Learner do
     end
   end
 
-  def __before_compile__(_env) do
+  defmacro __before_compile__(_env) do
     quote do
       def __annex__(_), do: nil
     end

--- a/lib/annex/learner.ex
+++ b/lib/annex/learner.ex
@@ -8,48 +8,70 @@ defmodule Annex.Learner do
   alias Annex.{
     Data,
     LayerConfig,
-    Utils
+    Optimizer,
+    Optimizer.SGD
   }
 
   require Logger
 
   @type t() :: struct()
   @type options :: Keyword.t()
-  @type data :: Data.data()
-  @type train_output :: %{atom() => any()}
 
-  @callback init_learner(t(), options()) :: {:ok, t()} | {:error, any()}
-  @callback train(t(), data(), data(), options()) :: {t(), train_output()}
-  @callback train_opts(options()) :: options()
+  @type training_output :: %{atom() => any()}
+
+  @type data :: Data.data()
+
+  @callback init_learner(t(), options()) :: t()
+
+  @callback train(t(), Dataset.t(), options()) :: {t(), training_output()}
   @callback predict(t(), data()) :: data()
+
+  @optional_callbacks [
+    train: 3,
+    init_learner: 2
+  ]
+
+  def __using__(_) do
+    quote do
+      def __annex__(:learner?), do: true
+
+      @before_compile Annex.Learner
+    end
+  end
+
+  def __before_compile__(_env) do
+    quote do
+      def __annex__(_), do: nil
+    end
+  end
+
+  @spec is_learner?(any) :: boolean()
+  def is_learner?(%module{}) do
+    is_learner?(module)
+  end
+
+  def is_learner?(module) do
+    is_atom(module) && function_exported?(module, :__annex__, 1) && module.__annex__(:learner?)
+  end
 
   @spec predict(t(), data()) :: data()
   def predict(%module{} = learner, data) do
     module.predict(learner, data)
   end
 
-  @spec train(t(), data(), data(), Keyword.t()) :: {:ok, t(), list(float())} | {:error, any()}
-  def train(learner, all_inputs, all_labels, opts \\ [])
+  @spec train(t(), Dataset.t(), Keyword.t()) :: {t(), training_output()}
+  def train(learner, dataset, opts \\ [])
 
-  def train(%LayerConfig{} = cfg, all_inputs, all_labels, opts) do
-    case LayerConfig.init_layer(cfg) do
-      {:ok, learner} ->
-        train(learner, all_inputs, all_labels, opts)
-
-      {:error, _} = error ->
-        error
-    end
+  def train(%LayerConfig{} = cfg, dataset, opts) do
+    cfg
+    |> LayerConfig.init_layer()
+    |> train(dataset, opts)
   end
 
-  def train(%module{} = learner, all_inputs, all_labels, opts) do
-    with(
-      {:ok, learner} <- module.init_learner(learner, opts),
-      {learner2, loss} <- do_train(learner, all_inputs, all_labels, opts)
-    ) do
-      {:ok, learner2, loss}
-    else
-      {:error, _} = err -> err
-    end
+  def train(%module{} = learner, dataset, opts) do
+    learner
+    |> module.init_learner(opts)
+    |> do_train(dataset, opts)
   end
 
   defp debug_logger(_learner, loss, epoch, opts) do
@@ -61,40 +83,36 @@ defmodule Annex.Learner do
         Learner -
         training: #{Keyword.get(opts, :name)}
         epoch: #{epoch}
-        loss: #{inspect(loss)}
+        output #{inspect(loss)}
         """
       end)
     end
   end
 
-  defp do_train(%module{} = learner, all_inputs, all_labels, opts) do
+  defp do_train(%learner_module{} = orig_learner, dataset, opts) do
     {halt_opt, opts} = Keyword.pop(opts, :halt_condition, {:epochs, 1_000})
     {log, opts} = Keyword.pop(opts, :log, &debug_logger/4)
+
+    {optimizer, opts} = Keyword.pop(opts, :optimizer, SGD)
     halt_condition = parse_halt_condition(halt_opt)
 
-    train_opts = module.train_opts(opts)
-
-    zipped = Utils.zip(all_inputs, all_labels)
-
-    fn ->
-      Enum.random(zipped)
-    end
-    |> Stream.repeatedly()
-    |> Stream.with_index(1)
-    |> Enum.reduce_while({learner, nil}, fn {{inputs, labels}, epoch},
-                                            {learner_acc, _prev_output} ->
-      {%_{} = learner2, loss} = module.train(learner_acc, inputs, labels, train_opts)
-
-      _ = log.(learner2, loss, epoch, [{:inputs, inputs}, {:labels, labels} | opts])
-
-      halt_or_cont =
-        if halt_condition.(learner2, loss, epoch, opts) do
-          :halt
+    1
+    |> Stream.iterate(fn epoch -> epoch + 1 end)
+    |> Enum.reduce_while(orig_learner, fn epoch, learner ->
+      {%_{} = learner2, training_output} =
+        if has_train?(learner_module) do
+          learner_module.train(learner, dataset, opts)
         else
-          :cont
+          Optimizer.train(optimizer, learner, dataset, opts)
         end
 
-      {halt_or_cont, {learner2, loss}}
+      _ = log.(learner2, training_output, epoch, opts)
+
+      if halt_condition.(learner2, training_output, epoch, opts) do
+        {:halt, {learner2, training_output}}
+      else
+        {:cont, learner2}
+      end
     end)
   end
 
@@ -102,6 +120,9 @@ defmodule Annex.Learner do
   def init_learner(%module{} = learner, options) do
     module.init_learner(learner, options)
   end
+
+  def has_train?(%module{}), do: has_train?(module)
+  def has_train?(module) when is_atom(module), do: function_exported?(module, :train, 3)
 
   defp parse_halt_condition(func) when is_function(func, 4) do
     func

--- a/lib/annex/optimizer.ex
+++ b/lib/annex/optimizer.ex
@@ -1,0 +1,13 @@
+defmodule Annex.Optimizer do
+  def batch_data(%optimizer_module{} = optimizer, dataset) do
+    if function_exported?(optimizer_module, :batch_data, 1) do
+      optimizer_module.batch_data(optimizer, dataset)
+    else
+      dataset
+    end
+  end
+
+  def train(optimizer, learner, dataset, opts) do
+    optimizer.train(learner, dataset, opts)
+  end
+end

--- a/lib/annex/optimizer.ex
+++ b/lib/annex/optimizer.ex
@@ -1,12 +1,18 @@
 defmodule Annex.Optimizer do
-  def batch_data(%optimizer_module{} = optimizer, dataset) do
-    if function_exported?(optimizer_module, :batch_data, 1) do
-      optimizer_module.batch_data(optimizer, dataset)
-    else
-      dataset
-    end
-  end
+  @moduledoc """
+  The Optimizer Behaviour and context for calling optimizer implementations.
 
+  """
+
+  alias Annex.{Dataset, Learner}
+
+  @type t :: module()
+
+  @callback train(Learner.t(), Dataset.t(), Keyword.t()) ::
+              {Learner.t(), Learner.training_output()}
+
+  @spec train(t(), Learner.t(), Dataset.t(), Keyword.t()) ::
+          {Learner.t(), Learner.training_output()}
   def train(optimizer, learner, dataset, opts) do
     optimizer.train(learner, dataset, opts)
   end

--- a/lib/annex/optimizer/sgd.ex
+++ b/lib/annex/optimizer/sgd.ex
@@ -25,7 +25,7 @@ defmodule Annex.Optimizer.SGD do
     batch_size = Keyword.get(opts, :batch_size)
     batched_dataset = batch_dataset(dataset, batch_size)
 
-    Enum.reduce(batched_dataset, orig_layer, fn {inputs, labels}, layer1 ->
+    Enum.reduce(batched_dataset, {orig_layer, %{}}, fn {inputs, labels}, {layer1, _output} ->
       {%{} = layer2, prediction} = Layer.feedforward(layer1, inputs)
 
       error = Data.error(prediction, labels)

--- a/lib/annex/optimizer/sgd.ex
+++ b/lib/annex/optimizer/sgd.ex
@@ -1,0 +1,56 @@
+defmodule Annex.Optimizer.SGD do
+  @moduledoc """
+  The optimizer for stochastic gradient descent.
+  """
+  alias Annex.{
+    Cost,
+    Data,
+    Defaults,
+    Layer,
+    Layer.Backprop
+  }
+
+  def train(%{} = learner, dataset, opts) do
+    cond do
+      Layer.is_layer?(learner) ->
+        train_layer(learner, dataset, opts)
+    end
+  end
+
+  defp train_layer(orig_layer, dataset, opts) do
+    batch_size = Keyword.get(opts, :batch_size, 1)
+    cost = Keyword.get_lazy(opts, :cost, fn -> Defaults.get_defaults(:cost) end)
+
+    batched_dataset = batch_dataset(dataset, batch_size)
+
+    Enum.reduce(batched_dataset, orig_layer, fn {inputs, labels}, layer1 ->
+      {%{} = layer2, prediction} = Layer.feedforward(layer1, inputs)
+
+      prediction = Data.to_flat_list(prediction)
+      labels = Data.to_flat_list(labels)
+
+      error = Data.error(prediction, labels)
+
+      props = Backprop.new()
+      {layer3, _error2, _props} = Layer.backprop(layer2, error, props)
+
+      loss = Cost.calculate(cost, error)
+
+      output = %{
+        loss: loss,
+        inputs: inputs,
+        labels: labels,
+        prediction: prediction,
+        error: error
+      }
+
+      {layer3, output}
+    end)
+  end
+
+  def batch_dataset(dataset, batch_size) do
+    dataset
+    |> Enum.shuffle()
+    |> Enum.take(batch_size)
+  end
+end

--- a/lib/annex/optimizer/sgd.ex
+++ b/lib/annex/optimizer/sgd.ex
@@ -10,6 +10,8 @@ defmodule Annex.Optimizer.SGD do
     Layer.Backprop
   }
 
+  import Annex.Utils, only: [is_pos_integer: 1]
+
   def train(%{} = learner, dataset, opts) do
     cond do
       Layer.is_layer?(learner) ->
@@ -18,16 +20,13 @@ defmodule Annex.Optimizer.SGD do
   end
 
   defp train_layer(orig_layer, dataset, opts) do
-    batch_size = Keyword.get(opts, :batch_size, 1)
     cost = Keyword.get_lazy(opts, :cost, fn -> Defaults.get_defaults(:cost) end)
 
+    batch_size = Keyword.get(opts, :batch_size)
     batched_dataset = batch_dataset(dataset, batch_size)
 
     Enum.reduce(batched_dataset, orig_layer, fn {inputs, labels}, layer1 ->
       {%{} = layer2, prediction} = Layer.feedforward(layer1, inputs)
-
-      prediction = Data.to_flat_list(prediction)
-      labels = Data.to_flat_list(labels)
 
       error = Data.error(prediction, labels)
 
@@ -48,7 +47,11 @@ defmodule Annex.Optimizer.SGD do
     end)
   end
 
-  def batch_dataset(dataset, batch_size) do
+  def batch_dataset(dataset, nil) do
+    dataset
+  end
+
+  def batch_dataset(dataset, batch_size) when is_pos_integer(batch_size) do
     dataset
     |> Enum.shuffle()
     |> Enum.take(batch_size)

--- a/lib/annex/utils.ex
+++ b/lib/annex/utils.ex
@@ -29,18 +29,6 @@ defmodule Annex.Utils do
   end
 
   @doc """
-  Random unifmormly splits a given `dataset` into two datasets at a given `frequency`.
-  """
-  def split_dataset(dataset, frequency) when frequency >= 0.0 and frequency <= 1.0 do
-    grouped =
-      dataset
-      |> Enum.shuffle()
-      |> Enum.group_by(fn _ -> :rand.uniform() > frequency end)
-
-    {Map.get(grouped, true, []), Map.get(grouped, false, [])}
-  end
-
-  @doc """
   A strict zip function in which the two given enumerables *must* be the same size.
   """
   @spec zip([any()], [any()]) :: [{any(), any()}]

--- a/test/and_test.exs
+++ b/test/and_test.exs
@@ -3,28 +3,18 @@ defmodule Annex.AndTest do
   alias Annex.Layer.Sequence
   alias Annex.LearnerHelper
 
-  @data [
-    [1.0, 1.0, 1.0],
-    [1.0, 0.0, 1.0],
-    [0.0, 0.0, 0.0],
-    [1.0, 0.0, 0.0],
-    [0.0, 0.0, 1.0],
-    [0.0, 1.0, 0.0],
-    [0.0, 1.0, 1.0]
-  ]
-
-  @labels [
-    [1.0],
-    [0.0],
-    [0.0],
-    [0.0],
-    [0.0],
-    [0.0],
-    [0.0]
+  @dataset [
+    {[1.0, 1.0, 1.0], [1.0]},
+    {[1.0, 0.0, 1.0], [0.0]},
+    {[0.0, 0.0, 0.0], [0.0]},
+    {[1.0, 0.0, 0.0], [0.0]},
+    {[0.0, 0.0, 1.0], [0.0]},
+    {[0.0, 1.0, 0.0], [0.0]},
+    {[0.0, 1.0, 1.0], [0.0]}
   ]
 
   test "and works" do
-    seq1 =
+    seq_config =
       Annex.sequence([
         Annex.dense(11, 3),
         Annex.activation(:tanh),
@@ -32,19 +22,17 @@ defmodule Annex.AndTest do
         Annex.activation(:tanh)
       ])
 
-    seq2 =
-      Annex.train(seq1, @data, @labels,
-        learning_rate: 0.15,
-        name: "AND operation",
-        halt_condition: {:epochs, 8000},
-        log: &LearnerHelper.test_logger/4,
-        log_interval: 1_000
-      )
+    assert {%Sequence{} = seq, _training_output} =
+             Annex.train(seq_config, @dataset,
+               learning_rate: 0.15,
+               name: "AND operation",
+               halt_condition: {:epochs, 8000},
+               log: &LearnerHelper.test_logger/4,
+               log_interval: 1_000
+             )
 
-    assert assert {:ok, %Sequence{} = seq3, _loss} = seq2
-
-    [should_be_true] = Annex.predict(seq3, [1.0, 1.0, 1.0])
-    [should_be_false] = Annex.predict(seq3, [1.0, 0.0, 1.0])
+    [should_be_true] = Annex.predict(seq, [1.0, 1.0, 1.0])
+    [should_be_false] = Annex.predict(seq, [1.0, 0.0, 1.0])
 
     assert_in_delta(should_be_true, 1.0, 0.1)
     assert_in_delta(should_be_false, 0.0, 0.1)

--- a/test/and_test.exs
+++ b/test/and_test.exs
@@ -26,9 +26,9 @@ defmodule Annex.AndTest do
              Annex.train(seq_config, @dataset,
                learning_rate: 0.15,
                name: "AND operation",
-               halt_condition: {:epochs, 8000},
+               halt_condition: {:epochs, 1500},
                log: &LearnerHelper.test_logger/4,
-               log_interval: 1_000
+               log_interval: 750
              )
 
     [should_be_true] = Annex.predict(seq, [1.0, 1.0, 1.0])

--- a/test/annex/data_test.exs
+++ b/test/annex/data_test.exs
@@ -134,20 +134,21 @@ defmodule Annex.DataTest do
     end
 
     test "works for DMatrix data" do
-      data = DMatrix.build([1.0, 2.0, 3.0])
-      assert Data.infer_type(data) == DMatrix
+      assert [1.0, 2.0, 3.0]
+             |> DMatrix.build()
+             |> Data.infer_type() == DMatrix
     end
 
     test "works for Layer" do
-      assert {:ok, %Dense{} = dense} = build(Dense, rows: 2, columns: 3)
-      assert Data.infer_type(dense) == DMatrix
+      assert Dense
+             |> build(rows: 2, columns: 3)
+             |> Data.infer_type() == DMatrix
     end
   end
 
   describe "data_type/1" do
     test "a built Dense layer defaults data_type to DMatrix" do
-      dense = build!(Dense, rows: 3, columns: 2)
-      assert %Dense{data_type: DMatrix} = dense
+      assert %Dense{data_type: DMatrix} = build(Dense, rows: 3, columns: 2)
     end
   end
 end

--- a/test/annex/layer/dense_test.exs
+++ b/test/annex/layer/dense_test.exs
@@ -8,14 +8,13 @@ defmodule Annex.Layer.DenseTest do
     Layer.Activation,
     Layer.Backprop,
     Layer.Dense,
-    Layer.Sequence,
     Utils
   }
 
   def fixture do
     weights = [-0.3333, 0.24, 0.1, 0.7, -0.4, -0.9]
     biases = [1.0, 1.0]
-    build!(Dense, rows: 2, columns: 3, weights: weights, baises: biases)
+    build(Dense, rows: 2, columns: 3, weights: weights, baises: biases)
   end
 
   test "dense feedforward works" do
@@ -44,7 +43,7 @@ defmodule Annex.Layer.DenseTest do
 
     assert output == DMatrix.build([[1.20667], [0.6699999999999999]])
     assert flat_output = DMatrix.to_flat_list(output)
-    error = Sequence.error(flat_output, labels)
+    error = Data.error(flat_output, labels)
 
     error_matrix =
       error
@@ -107,7 +106,7 @@ defmodule Annex.Layer.DenseTest do
            }
   end
 
-  @dense_2_by_3 build!(Dense,
+  @dense_2_by_3 build(Dense,
                   rows: 2,
                   columns: 3,
                   weights: [1.0, 1.0, 1.0, 0.5, 0.5, 0.5],
@@ -115,22 +114,22 @@ defmodule Annex.Layer.DenseTest do
                 )
   describe "init_layer/1" do
     test "ok for valid config with rows and columns" do
-      assert {:ok, %Dense{}} =
+      assert %Dense{} =
                Dense
                |> LayerConfig.build(rows: 2, columns: 3)
                |> Dense.init_layer()
     end
 
     test "ok for valid rows, columns, weights, and biases" do
-      assert {:ok, dense} =
-               Dense
-               |> LayerConfig.build(
-                 rows: 2,
-                 columns: 3,
-                 weights: [1.0, 1.0, 1.0, 0.5, 0.5, 0.5],
-                 biases: [1.0, 1.0]
-               )
-               |> Dense.init_layer()
+      dense =
+        Dense
+        |> LayerConfig.build(
+          rows: 2,
+          columns: 3,
+          weights: [1.0, 1.0, 1.0, 0.5, 0.5, 0.5],
+          biases: [1.0, 1.0]
+        )
+        |> Dense.init_layer()
 
       assert %Dense{
                weights: weights,

--- a/test/annex/layer/dropout_test.exs
+++ b/test/annex/layer/dropout_test.exs
@@ -10,42 +10,36 @@ defmodule Annex.Layer.DropoutTest do
 
   describe "init_layer/1" do
     test "ok for valid config" do
-      cfg = LayerConfig.build(Dropout, frequency: 0.5)
-      {:ok, layer} = Layer.init_layer(cfg)
-      assert %Dropout{frequency: 0.5} == layer
+      assert Dropout
+             |> LayerConfig.build(frequency: 0.5)
+             |> Layer.init_layer() == %Dropout{frequency: 0.5}
     end
 
-    test "error for invalid config" do
-      cfg = LayerConfig.build(Dropout, frequency: 1.5)
-      {:error, error} = Layer.init_layer(cfg)
-      message = "Dropout.build/1 requires a :frequency that is a float between 0.0 and 1.0"
-
-      assert error == %AnnexError{
-               message: message,
-               details: [
-                 invalid_frequency: 1.5,
-                 reason: :invalid_frequency_value
-               ]
-             }
+    test "raises for invalid config" do
+      assert_raise(AnnexError, fn ->
+        Dropout
+        |> LayerConfig.build(frequency: 1.5)
+        |> Layer.init_layer()
+      end)
     end
 
     test "works for frequency above 0.0 and less than or equal to 1.0" do
-      assert {:ok, _} = build(Dropout, frequency: 1.0)
-      assert {:ok, _} = build(Dropout, frequency: 0.444)
-      assert {:ok, _} = build(Dropout, frequency: 0.0)
+      assert %Dropout{frequency: 1.0} = build(Dropout, frequency: 1.0)
+      assert %Dropout{frequency: 0.444} = build(Dropout, frequency: 0.444)
+      assert %Dropout{frequency: 0.0} = build(Dropout, frequency: 0.0)
     end
 
-    test "errors for non-frequency" do
-      assert {:error, %AnnexError{}} = build(Dropout, frequency: 1.1)
-      assert {:error, %AnnexError{}} = build(Dropout, frequency: 1)
-      assert {:error, %AnnexError{}} = build(Dropout, frequency: :one)
-      assert {:error, %AnnexError{}} = build(Dropout, frequency: -1.0)
+    test "raises for non-frequency" do
+      assert_raise(AnnexError, fn -> build(Dropout, frequency: 1.1) end)
+      assert_raise(AnnexError, fn -> build(Dropout, frequency: 1) end)
+      assert_raise(AnnexError, fn -> build(Dropout, frequency: :one) end)
+      assert_raise(AnnexError, fn -> build(Dropout, frequency: -1.0) end)
     end
   end
 
   describe "feedforward/2" do
     test "works with a list of floats" do
-      layer1 = build!(Dropout, frequency: 0.5)
+      layer1 = build(Dropout, frequency: 0.5)
       original = 0.666
       {_layer2, pred} = Layer.feedforward(layer1, [original])
       assert [zeroed_or_original] = pred
@@ -53,7 +47,7 @@ defmodule Annex.Layer.DropoutTest do
     end
 
     test "dropout does not change on feedforward" do
-      layer1 = build!(Dropout, frequency: 0.5)
+      layer1 = build(Dropout, frequency: 0.5)
       {layer2, _pred} = Layer.feedforward(layer1, [1.0])
       assert layer1 == layer2
     end

--- a/test/annex/layer/sequence_test.exs
+++ b/test/annex/layer/sequence_test.exs
@@ -27,11 +27,12 @@ defmodule Annex.Layer.SequenceTest do
   end
 
   def generate_sequence(layer_configs) do
-    assert {:ok, seq} =
-             Sequence
-             |> LayerConfig.build(layers: layer_configs)
-             |> LayerConfig.init_layer()
+    seq =
+      Sequence
+      |> LayerConfig.build(layers: layer_configs)
+      |> LayerConfig.init_layer()
 
+    assert %Sequence{} = seq
     seq
   end
 
@@ -87,11 +88,12 @@ defmodule Annex.Layer.SequenceTest do
     assert_in_order(layers)
 
     # apply transform
-    assert {:ok, %Sequence{} = seq} =
-             layer_configs
-             |> seq_transform.()
-             |> Sequence.init_layer()
+    seq =
+      layer_configs
+      |> seq_transform.()
+      |> Sequence.init_layer()
 
+    assert %Sequence{} = seq
     # make sure seq is in order
     seq_layers = Sequence.get_layers(seq)
     assert MapArray.len(seq_layers) == n
@@ -133,8 +135,10 @@ defmodule Annex.Layer.SequenceTest do
     test "Sequence.init_layer/1 preserves ordering of layers", %{layer_configs: layer_configs} do
       seq_cfg = LayerConfig.build(Sequence, layers: layer_configs)
       assert_in_order(layer_configs)
-      assert {:ok, seq} = Sequence.init_layer(seq_cfg)
-      assert_in_order(seq)
+
+      seq_cfg
+      |> Sequence.init_layer()
+      |> assert_in_order()
     end
 
     test "Sequence.feedforward/2 preserves ordering of layers", %{seq: seq1} do
@@ -163,7 +167,7 @@ defmodule Annex.Layer.SequenceTest do
           biases: [1.0, 1.0]
         )
 
-      assert {:ok, seq} =
+      assert seq =
                Sequence
                |> LayerConfig.build(layers: [dense])
                |> Layer.init_layer()

--- a/test/annex/layer_test.exs
+++ b/test/annex/layer_test.exs
@@ -9,7 +9,7 @@ defmodule Annex.LayerTest do
   def dense_fixture do
     weights = [-0.3333, 0.24, 0.1, 0.7, -0.4, -0.9]
     biases = [1.0, 1.0]
-    build!(Dense, rows: 2, columns: 3, weights: weights, biases: biases)
+    build(Dense, rows: 2, columns: 3, weights: weights, biases: biases)
   end
 
   describe "forward_shape/1" do

--- a/test/annex/layer_test.exs
+++ b/test/annex/layer_test.exs
@@ -6,10 +6,53 @@ defmodule Annex.LayerTest do
     Layer.Dense
   }
 
+  defmodule LayerImplementer do
+    use Annex.Layer
+
+    defstruct some_field: nil
+
+    def init_layer(%LayerConfig{}) do
+      %LayerImplementer{}
+    end
+
+    def feedforward(%LayerImplementer{} = layer, inputs) do
+      {layer, inputs}
+    end
+
+    def backprop(%LayerImplementer{} = layer, error, backprops) do
+      {layer, error, backprops}
+    end
+  end
+
+  defmodule LayerNonImplementer do
+    defstruct thing: nil
+  end
+
   def dense_fixture do
     weights = [-0.3333, 0.24, 0.1, 0.7, -0.4, -0.9]
     biases = [1.0, 1.0]
     build(Dense, rows: 2, columns: 3, weights: weights, biases: biases)
+  end
+
+  describe "is_layer?/1" do
+    test "is true for a Layer-using module" do
+      assert Layer.is_layer?(%LayerImplementer{}) == true
+      assert Layer.is_layer?(LayerImplementer) == true
+    end
+
+    test "is false for a non-Layer-using module" do
+      assert Layer.is_layer?(%LayerNonImplementer{}) == false
+      assert Layer.is_layer?(LayerNonImplementer) == false
+    end
+
+    test "is false for a non-modules" do
+      assert Layer.is_layer?(:beef) == false
+      assert Layer.is_layer?('carrot') == false
+      assert Layer.is_layer?("cake") == false
+      assert Layer.is_layer?(1) == false
+      assert Layer.is_layer?(1.0) == false
+      assert Layer.is_layer?(nil) == false
+    end
   end
 
   describe "forward_shape/1" do

--- a/test/male_or_female_test.exs
+++ b/test/male_or_female_test.exs
@@ -17,15 +17,15 @@ defmodule Annex.SequenceMOrFTest do
     assert {%Sequence{} = seq, _training_output} =
              [
                Annex.dense(2, 2),
-               Annex.activation(:sigmoid),
+               Annex.activation(:tanh),
                Annex.dense(1, 2),
                Annex.activation(:sigmoid)
              ]
              |> Annex.sequence()
              |> Annex.train(dataset,
                name: "male or female based on normalized weight and height",
-               halt_condition: {:epochs, 8_000},
-               log_interval: 1_000
+               halt_condition: {:epochs, 2000},
+               log_interval: 1000
              )
 
     [alice_pred] = Annex.predict(seq, [-2.0, -1.0])

--- a/test/male_or_female_test.exs
+++ b/test/male_or_female_test.exs
@@ -3,29 +3,18 @@ defmodule Annex.SequenceMOrFTest do
   alias Annex.Layer.Sequence
 
   test "males vs females based on weight and height" do
-    data = [
+    dataset = [
       # Alice
-      [-2.0, -1.0],
+      {[-2.0, -1.0], [1.0]},
       # Bob
-      [25.0, 6.0],
+      {[25.0, 6.0], [0.0]},
       # Charlie
-      [17.0, 4.0],
+      {[17.0, 4.0], [0.0]},
       # Diana
-      [-15.0, -6.0]
+      {[-15.0, -6.0], [1.0]}
     ]
 
-    labels = [
-      # Alice
-      [1.0],
-      # Bob
-      [0.0],
-      # Charlie
-      [0.0],
-      # Diana
-      [1.0]
-    ]
-
-    assert {:ok, %Sequence{} = seq, _loss} =
+    assert {%Sequence{} = seq, _training_output} =
              [
                Annex.dense(2, 2),
                Annex.activation(:sigmoid),
@@ -33,7 +22,7 @@ defmodule Annex.SequenceMOrFTest do
                Annex.activation(:sigmoid)
              ]
              |> Annex.sequence()
-             |> Annex.train(data, labels,
+             |> Annex.train(dataset,
                name: "male or female based on normalized weight and height",
                halt_condition: {:epochs, 8_000},
                log_interval: 1_000

--- a/test/support/layer_helpers.ex
+++ b/test/support/layer_helpers.ex
@@ -2,31 +2,14 @@ defmodule Annex.LayerHelpers do
   @moduledoc """
   Helpers for building Layers.
   """
-  alias Annex.{
-    AnnexError,
-    LayerConfig
-  }
+  alias Annex.LayerConfig
 
   @type kvs :: map | keyword()
 
-  @spec build(atom, kvs) :: {:ok, struct()} | {:error, AnnexError.t()}
+  @spec build(atom, kvs) :: Layer.t()
   def build(module, kvs) do
     module
     |> LayerConfig.build(kvs)
     |> LayerConfig.init_layer()
-  end
-
-  @spec build!(atom, any) :: Layer.t()
-  def build!(module, kvs) do
-    module
-    |> LayerConfig.build(kvs)
-    |> LayerConfig.init_layer()
-    |> case do
-      {:ok, layer} ->
-        layer
-
-      {:error, %AnnexError{} = error} ->
-        raise error
-    end
   end
 end

--- a/test/support/learner_helpers.ex
+++ b/test/support/learner_helpers.ex
@@ -4,20 +4,16 @@ defmodule Annex.LearnerHelper do
   """
   require Logger
 
-  def test_logger(learner, loss, epoch, opts) do
-    log_interval = Keyword.get(opts, :log_interval, 10_000)
-    inputs = Keyword.get(opts, :inputs)
-    labels = Keyword.get(opts, :labels)
+  def test_logger(learner, training_output, epoch, opts) do
+    log_interval = Keyword.get(opts, :log_interval, 1000)
 
     if rem(epoch, log_interval) == 0 do
       Logger.debug(fn ->
         """
         Learner -
-        training: #{Keyword.get(opts, :name)}
+        learner_name: #{Keyword.get(opts, :name)}
         epoch: #{epoch}
-        loss: #{inspect(loss)}
-        inputs: #{inspect(inputs)}
-        labels: #{inspect(labels)}
+        training_output: #{inspect(training_output)}
         learner: #{inspect(learner)}
         """
       end)

--- a/test/xor2_test.exs
+++ b/test/xor2_test.exs
@@ -1,6 +1,7 @@
 defmodule Annex.SequenceXor2Test do
   use ExUnit.Case, async: true
   alias Annex.Layer.Sequence
+  alias Annex.Dataset
 
   test "xor2 test" do
     data = [
@@ -17,20 +18,22 @@ defmodule Annex.SequenceXor2Test do
       [0.0, 1.0]
     ]
 
-    {:ok, %Sequence{} = seq, _output} =
-      [
-        Annex.dense(11, 2),
-        Annex.activation(:relu),
-        Annex.dense(2, 11),
-        Annex.activation(:sigmoid)
-      ]
-      |> Annex.sequence()
-      |> Annex.train(data, labels,
-        name: "xor2",
-        learning_rate: 0.02,
-        halt_condition: {:epochs, 8000},
-        log_interval: 1000
-      )
+    dataset = Dataset.zip(data, labels)
+
+    assert {%Sequence{} = seq, _training_output} =
+             [
+               Annex.dense(11, 2),
+               Annex.activation(:relu),
+               Annex.dense(2, 11),
+               Annex.activation(:sigmoid)
+             ]
+             |> Annex.sequence()
+             |> Annex.train(dataset,
+               name: "xor2",
+               learning_rate: 0.02,
+               halt_condition: {:epochs, 8000},
+               log_interval: 1000
+             )
 
     [pred_yes, pred_no] = Annex.predict(seq, [0.0, 0.0])
     assert_in_delta(pred_yes, 0.0, 0.1)

--- a/test/xor2_test.exs
+++ b/test/xor2_test.exs
@@ -1,24 +1,14 @@
 defmodule Annex.SequenceXor2Test do
   use ExUnit.Case, async: true
   alias Annex.Layer.Sequence
-  alias Annex.Dataset
 
   test "xor2 test" do
-    data = [
-      [0.0, 0.0],
-      [0.0, 1.0],
-      [1.0, 0.0],
-      [1.0, 1.0]
+    dataset = [
+      {[0.0, 0.0], [0.0, 1.0]},
+      {[0.0, 1.0], [1.0, 0.0]},
+      {[1.0, 0.0], [1.0, 0.0]},
+      {[1.0, 1.0], [0.0, 1.0]}
     ]
-
-    labels = [
-      [0.0, 1.0],
-      [1.0, 0.0],
-      [1.0, 0.0],
-      [0.0, 1.0]
-    ]
-
-    dataset = Dataset.zip(data, labels)
 
     assert {%Sequence{} = seq, _training_output} =
              [
@@ -31,8 +21,8 @@ defmodule Annex.SequenceXor2Test do
              |> Annex.train(dataset,
                name: "xor2",
                learning_rate: 0.02,
-               halt_condition: {:epochs, 8000},
-               log_interval: 1000
+               halt_condition: {:epochs, 1200},
+               log_interval: 600
              )
 
     [pred_yes, pred_no] = Annex.predict(seq, [0.0, 0.0])

--- a/test/xor_test.exs
+++ b/test/xor_test.exs
@@ -1,23 +1,17 @@
 defmodule Annex.SequenceXorTest do
   use ExUnit.Case, async: true
+
   alias Annex.Layer.Sequence
 
   test "xor test" do
-    data = [
-      [0.0, 0.0],
-      [0.0, 1.0],
-      [1.0, 0.0],
-      [1.0, 1.0]
+    dataset = [
+      {[0.0, 0.0], [0.0]},
+      {[0.0, 1.0], [1.0]},
+      {[1.0, 0.0], [1.0]},
+      {[1.0, 1.0], [0.0]}
     ]
 
-    labels = [
-      [0.0],
-      [1.0],
-      [1.0],
-      [0.0]
-    ]
-
-    assert {:ok, %Sequence{} = seq, _loss} =
+    assert {%Sequence{} = seq, _training_output} =
              [
                Annex.dense(8, 2),
                Annex.activation(:tanh),
@@ -25,7 +19,7 @@ defmodule Annex.SequenceXorTest do
                Annex.activation(:sigmoid)
              ]
              |> Annex.sequence()
-             |> Annex.train(data, labels,
+             |> Annex.train(dataset,
                name: "XOR operation",
                learning_rate: 0.05,
                halt_condition: {:epochs, 8_000},

--- a/test/xor_test.exs
+++ b/test/xor_test.exs
@@ -22,8 +22,8 @@ defmodule Annex.SequenceXorTest do
              |> Annex.train(dataset,
                name: "XOR operation",
                learning_rate: 0.05,
-               halt_condition: {:epochs, 8_000},
-               log_interval: 1_000
+               halt_condition: {:epochs, 1500},
+               log_interval: 750
              )
 
     [zero_zero] = Annex.predict(seq, [0.0, 0.0])


### PR DESCRIPTION
This PR adds the `Annex.Optimizer` behaviour.

So far, the `Annex.Optimizer` behaviour only has 1 function `train/3`. The `train/3` of `Annex.Optimizer` is the exact same function specification as the `Annex.Learner` `train/3` callback.

It may be a good idea to create an `Annex.Learner.Trainer` behaviour. This would DRY up the `train/3`specification that is currently in two places but must, in fact, be the same specification.

Additionally, this PR adds `Annex.Optimizer.SGD` which is an `Annex.Optimizer` implementation for running mini-batch (or not batched at all) stochastic gradient descent.