### PR TITLE
Fix SGD backprop integrity and improve handling of Annex.Defaults values

### DIFF
--- a/lib/annex/defaults.ex
+++ b/lib/annex/defaults.ex
@@ -15,8 +15,8 @@ defmodule Annex.Defaults do
   end
 
   @spec cost() :: module()
-  def cost, do: get_defaults(:cost, MeanSquaredError)
+  def cost, do: get_defaults(:cost) || MeanSquaredError
 
   @spec learning_rate() :: float()
-  def learning_rate, do: get_defaults(:learning_rate, 0.05)
+  def learning_rate, do: get_defaults(:learning_rate) || 0.05
 end

--- a/lib/annex/optimizer/sgd.ex
+++ b/lib/annex/optimizer/sgd.ex
@@ -47,7 +47,7 @@ defmodule Annex.Optimizer.SGD do
 
       error = Data.error(prediction, labels)
 
-      props = Backprop.new()
+      props = Backprop.new(opts)
       {layer3, _error2, _props} = Layer.backprop(layer2, error, props)
 
       loss = Cost.calculate(cost, error)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Annex.MixProject do
   def project do
     [
       app: :annex,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/xor2_test.exs
+++ b/test/xor2_test.exs
@@ -20,7 +20,7 @@ defmodule Annex.SequenceXor2Test do
              |> Annex.sequence()
              |> Annex.train(dataset,
                name: "xor2",
-               learning_rate: 0.02,
+               learning_rate: 0.1,
                halt_condition: {:epochs, 1200},
                log_interval: 600
              )


### PR DESCRIPTION
This PR passes the backprops into Backprop.new/1 inside the SGD optimizer ensuring they are passed through the backprop pipeline.

Also, this PR reduces the chance that non configured Annex.Default configuration values become `nil`


